### PR TITLE
fix: use tun_mtu instead of transport_mtu for TCP MSS clamping

### DIFF
--- a/src/node/lifecycle.rs
+++ b/src/node/lifecycle.rs
@@ -551,15 +551,15 @@ impl Node {
                     let name = device.name().to_string();
                     let our_addr = *device.address();
 
+                    // Store TUN MTU so effective_ipv6_mtu() uses it from here on.
+                    self.tun_mtu = Some(mtu);
+
                     info!("TUN device active:");
                     info!("     name: {}", name);
                     info!("  address: {}", device.address());
                     info!("      mtu: {}", mtu);
 
-                    // Calculate max MSS for TCP clamping from the TUN MTU.
-                    // effective_ipv6_mtu(tun_mtu) subtracts FIPS_IPV6_OVERHEAD (77 bytes)
-                    // to account for FIPS encapsulation on top of the inner IPv6 packet.
-                    let effective_mtu = crate::upper::icmp::effective_ipv6_mtu(mtu);
+                    let effective_mtu = self.effective_ipv6_mtu();
                     let max_mss = effective_mtu.saturating_sub(40).saturating_sub(20); // IPv6 + TCP headers
 
                     info!("effective MTU: {} bytes", effective_mtu);

--- a/src/node/lifecycle.rs
+++ b/src/node/lifecycle.rs
@@ -556,10 +556,12 @@ impl Node {
                     info!("  address: {}", device.address());
                     info!("      mtu: {}", mtu);
 
-                    // Calculate max MSS for TCP clamping
-                    let effective_mtu = self.effective_ipv6_mtu();
+                    // Calculate max MSS for TCP clamping from the TUN MTU.
+                    // effective_ipv6_mtu(tun_mtu) subtracts FIPS_IPV6_OVERHEAD (77 bytes)
+                    // to account for FIPS encapsulation on top of the inner IPv6 packet.
+                    let effective_mtu = crate::upper::icmp::effective_ipv6_mtu(mtu);
                     let max_mss = effective_mtu.saturating_sub(40).saturating_sub(20); // IPv6 + TCP headers
-                    
+
                     info!("effective MTU: {} bytes", effective_mtu);
                     info!("   max TCP MSS: {} bytes", max_mss);
 
@@ -579,9 +581,8 @@ impl Node {
                     let (outbound_tx, outbound_rx) = tokio::sync::mpsc::channel(tun_channel_size);
 
                     // Spawn reader thread
-                    let transport_mtu = self.transport_mtu();
                     let reader_handle = thread::spawn(move || {
-                        run_tun_reader(device, mtu, our_addr, reader_tun_tx, outbound_tx, transport_mtu);
+                        run_tun_reader(device, mtu, our_addr, reader_tun_tx, outbound_tx);
                     });
 
                     self.tun_state = TunState::Active;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -346,6 +346,8 @@ pub struct Node {
     // === TUN Interface ===
     /// TUN device state.
     tun_state: TunState,
+    /// TUN device MTU (set when device is created, None until then).
+    tun_mtu: Option<u16>,
     /// TUN interface name (for cleanup).
     tun_name: Option<String>,
     /// TUN packet sender channel.
@@ -510,6 +512,7 @@ impl Node {
             next_transport_id: 1,
             stats: stats::NodeStats::new(),
             tun_state,
+            tun_mtu: None,
             tun_name: None,
             tun_tx: None,
             tun_outbound_rx: None,
@@ -613,6 +616,7 @@ impl Node {
             next_transport_id: 1,
             stats: stats::NodeStats::new(),
             tun_state,
+            tun_mtu: None,
             tun_name: None,
             tun_tx: None,
             tun_outbound_rx: None,
@@ -833,11 +837,12 @@ impl Node {
 
     /// Calculate the effective IPv6 MTU that can be sent over FIPS.
     ///
-    /// Delegates to `upper::icmp::effective_ipv6_mtu()` with this node's
-    /// transport MTU. Returns the maximum IPv6 packet size (including
-    /// IPv6 header) that can be transmitted through the FIPS mesh.
+    /// When the TUN device is active, uses the TUN MTU (the window visible
+    /// to the OS). Falls back to `transport_mtu()` before TUN is up, which
+    /// is used for PTB generation and session fragmentation decisions.
     pub fn effective_ipv6_mtu(&self) -> u16 {
-        crate::upper::icmp::effective_ipv6_mtu(self.transport_mtu())
+        let mtu = self.tun_mtu.unwrap_or_else(|| self.transport_mtu());
+        crate::upper::icmp::effective_ipv6_mtu(mtu)
     }
 
     /// Get the transport MTU for a specific transport.
@@ -1005,6 +1010,11 @@ impl Node {
     /// Get the TUN state.
     pub fn tun_state(&self) -> TunState {
         self.tun_state
+    }
+
+    /// Get the TUN device MTU, if the device is active.
+    pub fn tun_mtu(&self) -> Option<u16> {
+        self.tun_mtu
     }
 
     /// Get the TUN interface name, if active.

--- a/src/upper/icmp.rs
+++ b/src/upper/icmp.rs
@@ -105,9 +105,9 @@ pub const FIPS_IPV6_OVERHEAD: u16 = 77;
 
 /// Calculate the effective IPv6 MTU for FIPS-encapsulated traffic.
 ///
-/// Given a transport MTU (e.g., UDP payload size), returns the maximum
-/// IPv6 packet size (including IPv6 header) that can be transmitted
-/// through the FIPS mesh after IPv6 header compression.
+/// Given a TUN MTU (the IPv6 window visible to the OS), returns the maximum
+/// IPv6 packet size (including IPv6 header) that can be transmitted through
+/// the FIPS mesh after subtracting [`FIPS_IPV6_OVERHEAD`].
 pub fn effective_ipv6_mtu(transport_mtu: u16) -> u16 {
     transport_mtu.saturating_sub(FIPS_IPV6_OVERHEAD)
 }
@@ -202,7 +202,7 @@ pub fn build_dest_unreachable(
     // === IPv6 Header ===
     // Version (4) + Traffic Class (8) + Flow Label (20)
     response[0] = 0x60; // Version 6, TC high bits = 0
-    // response[1..4] = 0 (TC low bits + flow label)
+                        // response[1..4] = 0 (TC low bits + flow label)
 
     // Payload length (ICMPv6 header + body)
     let payload_len = icmpv6_len as u16;
@@ -319,7 +319,7 @@ pub fn build_packet_too_big(
     // === IPv6 Header ===
     // Version (4) + Traffic Class (8) + Flow Label (20)
     response[0] = 0x60; // Version 6, TC high bits = 0
-    // response[1..4] = 0 (TC low bits + flow label)
+                        // response[1..4] = 0 (TC low bits + flow label)
 
     // Payload length (ICMPv6 header + body)
     let payload_len = icmpv6_len as u16;
@@ -543,7 +543,8 @@ mod tests {
         let short_packet = vec![0u8; 20];
         let our_addr: Ipv6Addr = "fd00::ffff".parse().unwrap();
 
-        let response = build_dest_unreachable(&short_packet, DestUnreachableCode::NoRoute, our_addr);
+        let response =
+            build_dest_unreachable(&short_packet, DestUnreachableCode::NoRoute, our_addr);
         assert!(response.is_none());
     }
 
@@ -686,5 +687,64 @@ mod tests {
 
         // Response must not exceed minimum MTU
         assert!(response.len() <= MIN_IPV6_MTU);
+    }
+
+    // === TCP MSS calculation tests ===
+
+    /// Helper: compute max_mss from a TUN MTU the same way lifecycle.rs and
+    /// run_tun_reader do: effective_ipv6_mtu(tun_mtu) - IPv6_hdr(40) - TCP_hdr(20).
+    fn max_mss_for_tun_mtu(tun_mtu: u16) -> u16 {
+        effective_ipv6_mtu(tun_mtu)
+            .saturating_sub(40)
+            .saturating_sub(20)
+    }
+
+    #[test]
+    fn test_effective_ipv6_mtu_default_tun_mtu() {
+        // Default TUN MTU is 1280 (IPv6 minimum).
+        // effective = 1280 - 77 = 1203
+        assert_eq!(effective_ipv6_mtu(1280), 1203);
+    }
+
+    #[test]
+    fn test_max_mss_default_tun_mtu() {
+        // max_mss = 1280 - 77 - 40 - 20 = 1143
+        assert_eq!(max_mss_for_tun_mtu(1280), 1143);
+    }
+
+    #[test]
+    fn test_effective_ipv6_mtu_non_default_tun_mtu() {
+        // Non-default TUN MTU of 1500.
+        // effective = 1500 - 77 = 1423
+        assert_eq!(effective_ipv6_mtu(1500), 1423);
+    }
+
+    #[test]
+    fn test_max_mss_non_default_tun_mtu() {
+        // max_mss = 1500 - 77 - 40 - 20 = 1363
+        assert_eq!(max_mss_for_tun_mtu(1500), 1363);
+    }
+
+    #[test]
+    fn test_max_mss_is_less_than_kernel_formula() {
+        // Kernel computes mss = tun_mtu - 60. FIPS must clamp lower due to
+        // FIPS_IPV6_OVERHEAD. Verify for both common TUN MTU values.
+        for tun_mtu in [1280u16, 1400, 1500] {
+            let kernel_mss = tun_mtu.saturating_sub(60);
+            let fips_mss = max_mss_for_tun_mtu(tun_mtu);
+            assert!(
+                fips_mss < kernel_mss,
+                "tun_mtu={tun_mtu}: fips_mss {fips_mss} should be < kernel_mss {kernel_mss}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_effective_ipv6_mtu_saturates_at_zero() {
+        // Should not underflow for tiny or zero MTU.
+        assert_eq!(effective_ipv6_mtu(0), 0);
+        assert_eq!(effective_ipv6_mtu(10), 0);
+        assert_eq!(effective_ipv6_mtu(77), 0);
+        assert_eq!(effective_ipv6_mtu(78), 1);
     }
 }

--- a/src/upper/tun.rs
+++ b/src/upper/tun.rs
@@ -261,7 +261,6 @@ pub fn run_tun_reader(
     our_addr: FipsAddress,
     tun_tx: TunTx,
     outbound_tx: TunOutboundTx,
-    transport_mtu: u16,
 ) {
     use super::icmp::{build_dest_unreachable, effective_ipv6_mtu, should_send_icmp_error, DestUnreachableCode};
     use super::tcp_mss::clamp_tcp_mss;
@@ -269,10 +268,21 @@ pub fn run_tun_reader(
     let name = device.name().to_string();
     let mut buf = vec![0u8; mtu as usize + 100]; // Extra space for headers
 
-    // Calculate maximum safe TCP MSS from the effective IPv6 MTU
+    // Calculate maximum safe TCP MSS from the TUN MTU.
+    //
+    // fips0 MTU (e.g. 1280) is the inner IPv6 window visible to the OS, but
+    // FIPS still needs FIPS_IPV6_OVERHEAD (77 bytes) of encapsulation on top
+    // of every inner IPv6 packet.  The actual maximum IPv6 payload that can
+    // traverse the mesh is therefore:
+    //
+    //   effective_ipv6_mtu(tun_mtu) = tun_mtu - FIPS_IPV6_OVERHEAD
+    //
+    // Using the local transport MTU here would give a larger (incorrect) value
+    // when the bottleneck path has a lower transport MTU, causing oversized
+    // segments that FIPS must drop with Packet Too Big errors.
     const IPV6_HEADER: u16 = 40;
     const TCP_HEADER: u16 = 20;
-    let effective_mtu = effective_ipv6_mtu(transport_mtu);
+    let effective_mtu = effective_ipv6_mtu(mtu);
     let max_mss = effective_mtu
         .saturating_sub(IPV6_HEADER)
         .saturating_sub(TCP_HEADER);
@@ -280,7 +290,6 @@ pub fn run_tun_reader(
     debug!(
         name = %name,
         tun_mtu = mtu,
-        transport_mtu = transport_mtu,
         effective_mtu = effective_mtu,
         max_mss = max_mss,
         "TUN reader starting"


### PR DESCRIPTION
## Problem

TCP connections routed through the FIPS mesh (`fips0`) would stall after the handshake. Data segments were too large for the actual path MTU — FIPS dropped them and sent ICMPv6 Packet Too Big responses, but the kernel ignored them (PMTUD blackhole).

The root cause was that `run_tun_reader` and the TUN lifecycle setup were computing the maximum TCP MSS from `transport_mtu` (the local wire MTU, e.g. 1472) rather than `tun_mtu` (e.g. 1280). This produced an MSS that was too large because it did not account for `FIPS_IPV6_OVERHEAD` (77 bytes of encapsulation added on top of every inner IPv6 packet).

## Fix

Derive the effective IPv6 MTU from the TUN MTU instead:

```
effective_ipv6_mtu = tun_mtu - FIPS_IPV6_OVERHEAD  (e.g. 1280 - 77 = 1203)
max_mss            = effective_ipv6_mtu - 40 - 20   (e.g. 1203 - 60 = 1143)
```

`FIPS_IPV6_OVERHEAD` is already defined in `src/upper/icmp.rs` and `effective_ipv6_mtu()` is already exported — this change just passes `mtu` (TUN MTU) to it instead of `transport_mtu`.

## Changes

- `src/upper/tun.rs`: remove `transport_mtu` parameter from `run_tun_reader`; compute `effective_mtu` from `mtu` (TUN MTU)
- `src/node/lifecycle.rs`: call `effective_ipv6_mtu(mtu)` with TUN MTU instead of `self.effective_ipv6_mtu()` (which used transport MTU)