### PR TITLE
Fix ICMPv6 Packet Too Big ignored by kernel (PTB from self)

### DIFF
--- a/src/node/handlers/session.rs
+++ b/src/node/handlers/session.rs
@@ -1665,7 +1665,6 @@ impl Node {
     /// misconfigured applications sending repeated oversized packets.
     pub(in crate::node) fn send_icmpv6_packet_too_big(&mut self, original_packet: &[u8], mtu: u32) {
         use crate::upper::icmp::build_packet_too_big;
-        use crate::FipsAddress;
         use std::net::Ipv6Addr;
 
         // Extract source address for rate limiting
@@ -1683,17 +1682,21 @@ impl Node {
             return;
         }
 
-        let our_ipv6 = FipsAddress::from_node_addr(self.node_addr()).to_ipv6();
-        if let Some(response) = build_packet_too_big(original_packet, mtu, our_ipv6)
+        // Use the original packet's *destination* as the ICMP source so the
+        // kernel sees the PTB coming from a remote router, not from itself.
+        // Linux ignores PTBs whose source matches a local address, which
+        // causes a PMTUD blackhole when both src and ICMP-src are local.
+        let dest_addr = Ipv6Addr::from(<[u8; 16]>::try_from(&original_packet[24..40]).unwrap());
+        if let Some(response) = build_packet_too_big(original_packet, mtu, dest_addr)
             && let Some(tun_tx) = &self.tun_tx
         {
             debug!(
                 src = %src_addr,
-                dst = %our_ipv6,
+                dst = %dest_addr,
                 packet_size = original_packet.len(),
                 reported_mtu = mtu,
                 "Sending ICMP Packet Too Big (ICMP src={}, dst={})",
-                our_ipv6,
+                dest_addr,
                 src_addr
             );
             let _ = tun_tx.send(response);

--- a/src/node/tests/session.rs
+++ b/src/node/tests/session.rs
@@ -1779,6 +1779,14 @@ async fn test_tun_outbound_path_mtu_generates_ptb() {
     assert_eq!(ptb[40], 2, "ICMPv6 type should be Packet Too Big (2)");
     assert_eq!(ptb[41], 0, "ICMPv6 code should be 0");
 
+    // Verify PTB source is the *remote peer* (original packet's destination),
+    // NOT the local node. Linux ignores PTBs whose source matches a local
+    // address, causing a PMTUD blackhole.
+    let ptb_src = std::net::Ipv6Addr::from(<[u8; 16]>::try_from(&ptb[8..24]).unwrap());
+    let ptb_dst = std::net::Ipv6Addr::from(<[u8; 16]>::try_from(&ptb[24..40]).unwrap());
+    assert_eq!(ptb_src, dst_fips.to_ipv6(), "PTB source must be remote peer (original dst), not local node");
+    assert_eq!(ptb_dst, src_fips.to_ipv6(), "PTB destination must be local node (original src)");
+
     // Verify reported MTU (32-bit field at ICMPv6 header bytes 4-7)
     let reported_mtu = u32::from_be_bytes([ptb[44], ptb[45], ptb[46], ptb[47]]);
     assert_eq!(reported_mtu, reduced_ipv6_mtu as u32, "Reported MTU should match path IPv6 MTU");
@@ -1903,6 +1911,14 @@ async fn test_multihop_pmtud_heterogeneous_mtu() {
     assert_eq!(ptb[6], 58, "Next header should be ICMPv6 (58)");
     assert_eq!(ptb[40], 2, "ICMPv6 type should be Packet Too Big (2)");
     assert_eq!(ptb[41], 0, "ICMPv6 code should be 0");
+
+    // Verify PTB source is the *remote peer* (original packet's destination),
+    // NOT the local node. Linux ignores PTBs whose source matches a local
+    // address, causing a PMTUD blackhole.
+    let ptb_src = std::net::Ipv6Addr::from(<[u8; 16]>::try_from(&ptb[8..24]).unwrap());
+    let ptb_dst = std::net::Ipv6Addr::from(<[u8; 16]>::try_from(&ptb[24..40]).unwrap());
+    assert_eq!(ptb_src, dst_fips.to_ipv6(), "PTB source must be remote peer (original dst), not local node");
+    assert_eq!(ptb_dst, src_fips.to_ipv6(), "PTB destination must be local node (original src)");
 
     // Verify reported MTU is the path MTU (not local MTU)
     let reported_mtu = u32::from_be_bytes([ptb[44], ptb[45], ptb[46], ptb[47]]);

--- a/src/upper/icmp.rs
+++ b/src/upper/icmp.rs
@@ -202,7 +202,7 @@ pub fn build_dest_unreachable(
     // === IPv6 Header ===
     // Version (4) + Traffic Class (8) + Flow Label (20)
     response[0] = 0x60; // Version 6, TC high bits = 0
-    // response[1..4] = 0 (TC low bits + flow label)
+                        // response[1..4] = 0 (TC low bits + flow label)
 
     // Payload length (ICMPv6 header + body)
     let payload_len = icmpv6_len as u16;
@@ -319,7 +319,7 @@ pub fn build_packet_too_big(
     // === IPv6 Header ===
     // Version (4) + Traffic Class (8) + Flow Label (20)
     response[0] = 0x60; // Version 6, TC high bits = 0
-    // response[1..4] = 0 (TC low bits + flow label)
+                        // response[1..4] = 0 (TC low bits + flow label)
 
     // Payload length (ICMPv6 header + body)
     let payload_len = icmpv6_len as u16;
@@ -543,7 +543,8 @@ mod tests {
         let short_packet = vec![0u8; 20];
         let our_addr: Ipv6Addr = "fd00::ffff".parse().unwrap();
 
-        let response = build_dest_unreachable(&short_packet, DestUnreachableCode::NoRoute, our_addr);
+        let response =
+            build_dest_unreachable(&short_packet, DestUnreachableCode::NoRoute, our_addr);
         assert!(response.is_none());
     }
 
@@ -686,5 +687,58 @@ mod tests {
 
         // Response must not exceed minimum MTU
         assert!(response.len() <= MIN_IPV6_MTU);
+    }
+
+    /// Verify that when the ICMP source is set to the original packet's
+    /// destination (the remote peer), the PTB is correctly formed.
+    ///
+    /// This is the critical fix for the PMTUD blackhole: Linux ignores
+    /// ICMPv6 PTBs whose source matches a local address. By using the
+    /// remote peer's address as the ICMP source, the kernel sees the PTB
+    /// as coming from a "remote router" and honors it.
+    #[test]
+    fn test_build_packet_too_big_remote_source_for_pmtud() {
+        let local_addr: Ipv6Addr = "fd41::1".parse().unwrap();
+        let remote_addr: Ipv6Addr = "fddf::2".parse().unwrap();
+        let original = make_ipv6_packet(local_addr, remote_addr, 6, &[0u8; 1200]); // TCP
+
+        // Pass remote_addr as our_addr — this is what send_icmpv6_packet_too_big
+        // does after the fix (original packet's dst = remote peer).
+        let response = build_packet_too_big(&original, 1203, remote_addr);
+        assert!(response.is_some());
+        let response = response.unwrap();
+
+        // PTB source must be the remote peer (not local)
+        let ptb_src = Ipv6Addr::from(<[u8; 16]>::try_from(&response[8..24]).unwrap());
+        assert_eq!(
+            ptb_src, remote_addr,
+            "PTB source must be remote peer address"
+        );
+
+        // PTB destination must be the local sender (original src)
+        let ptb_dst = Ipv6Addr::from(<[u8; 16]>::try_from(&response[24..40]).unwrap());
+        assert_eq!(
+            ptb_dst, local_addr,
+            "PTB destination must be original sender"
+        );
+
+        // Verify ICMPv6 type/code
+        assert_eq!(response[IPV6_HEADER_LEN], 2); // Type = Packet Too Big
+        assert_eq!(response[IPV6_HEADER_LEN + 1], 0); // Code = 0
+
+        // Verify reported MTU
+        let reported_mtu = u32::from_be_bytes([
+            response[IPV6_HEADER_LEN + 4],
+            response[IPV6_HEADER_LEN + 5],
+            response[IPV6_HEADER_LEN + 6],
+            response[IPV6_HEADER_LEN + 7],
+        ]);
+        assert_eq!(reported_mtu, 1203);
+
+        // Verify checksum is valid (recalculate and compare)
+        let stored_checksum =
+            u16::from_be_bytes([response[IPV6_HEADER_LEN + 2], response[IPV6_HEADER_LEN + 3]]);
+        let recomputed = icmpv6_checksum(&response[IPV6_HEADER_LEN..], &remote_addr, &local_addr);
+        assert_eq!(stored_checksum, recomputed, "ICMPv6 checksum must be valid");
     }
 }


### PR DESCRIPTION
## Summary

- Fix PMTUD blackhole where Linux kernel ignored ICMPv6 Packet Too Big messages. Add test coverage for the fix.

## Root Cause

When FIPS detects an oversized outbound packet on the TUN interface, it generates an ICMPv6 Packet Too Big and writes it back to TUN so the kernel updates its PMTU cache.

FIPS acts as an on-path router, but shares the same address as the sending application. The PTB source and destination were both the local FIPS address — which is semantically correct (we are the router that rejected the packet), but the kernel ignores PTBs where src == dst.

```
src: fd41:...:local  dst: fd41:...:local  ICMP6, packet too big, mtu 1203  (ignored — src == dst)
```

The PMTU cache was never updated, so TCP kept sending oversized segments, FIPS kept generating ignored PTBs, and connections stalled after the handshake.

## Fix

Use the remote peer's address as the PTB source. This is not strictly accurate (the remote peer didn't reject the packet — we did), but it's the only available address that differs from the local address and makes the kernel honor the PTB:

```
src: fddf:...:remote  dst: fd41:...:local  ICMP6, packet too big, mtu 1203  (honored — src != dst)
```

## Tests

- New unit test `test_build_packet_too_big_remote_source_for_pmtud` in `src/upper/icmp.rs`
- Added PTB source/destination address assertions to existing integration tests `test_tun_outbound_path_mtu_generates_ptb` and `test_multihop_pmtud_heterogeneous_mtu`