### PR TITLE
ci: rename package-openwrt.yml to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: OpenWrt Package
+name: Release
 
 on:
   push:


### PR DESCRIPTION
depends on #21 

## Summary
- Rename `package-openwrt.yml` to `release.yml` via `git mv` (clean rename)
- Update workflow display name from "OpenWrt Package" to "Release"
- No functional changes -- all jobs, triggers, and steps are identical

This prepares the workflow for adding AUR publish jobs in a follow-up PR, creating a unified release workflow that handles both OpenWrt .ipk packages and AUR package publishing. Can be easily extended later for other packages.

## Notes
- GitHub Actions UI may show both "OpenWrt Package" (old runs) and "Release" (new runs) entries temporarily. The old entry stops accumulating runs and can be deleted via Actions tab.