### PR TITLE
ci: add AUR publish workflow for tagged releases

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -10,6 +10,7 @@ jobs:
     name: Publish fips to AUR
     runs-on: ubuntu-latest
     continue-on-error: true
+    if: "!contains(github.ref_name, '-')"
 
     steps:
       - uses: actions/checkout@v4
@@ -33,25 +34,3 @@ jobs:
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           commit_message: "Update to ${{ github.ref_name }}"
-
-  aur-publish-git:
-    name: Publish fips-git to AUR
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Publish to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
-        with:
-          pkgname: fips-git
-          pkgbuild: packaging/aur/PKGBUILD-git
-          assets: |
-            packaging/aur/fips.sysusers
-            packaging/aur/fips.tmpfiles
-            packaging/aur/fips.install
-          commit_username: ${{ github.repository_owner }}
-          commit_email: ${{ secrets.AUR_EMAIL }}
-          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-          commit_message: "Bump for ${{ github.ref_name }} release"

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -1,0 +1,57 @@
+name: AUR Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  aur-publish-fips:
+    name: Publish fips to AUR
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update pkgver in PKGBUILD
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" packaging/aur/PKGBUILD
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
+        with:
+          pkgname: fips
+          pkgbuild: packaging/aur/PKGBUILD
+          updpkgsums: true
+          assets: |
+            packaging/aur/fips.sysusers
+            packaging/aur/fips.tmpfiles
+            packaging/aur/fips.install
+          commit_username: ${{ github.repository_owner }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "Update to ${{ github.ref_name }}"
+
+  aur-publish-git:
+    name: Publish fips-git to AUR
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
+        with:
+          pkgname: fips-git
+          pkgbuild: packaging/aur/PKGBUILD-git
+          assets: |
+            packaging/aur/fips.sysusers
+            packaging/aur/fips.tmpfiles
+            packaging/aur/fips.install
+          commit_username: ${{ github.repository_owner }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "Bump for ${{ github.ref_name }} release"


### PR DESCRIPTION
## Summary
- Add `aur-publish.yml` workflow triggered on `v*` tag pushes
- `aur-publish-fips` job: updates `pkgver` via sed, recomputes checksums via `updpkgsums`, pushes release PKGBUILD to AUR
- Only fires on stable releases — tags containing `-` (alpha/beta/dev) are skipped via `if: "!contains(github.ref_name, '-')"`
- Non-blocking (`continue-on-error: true`)
- Uses `KSXGitHub/github-actions-deploy-aur@v4.1.1`

Note: `fips-git` is not pushed by CI — `-git` AUR packages are designed for users to build locally from HEAD and do not require a CI trigger.

## Required Secrets

Before the first tagged release, configure these GitHub repository secrets:

| Secret | Purpose | Source |
|--------|---------|--------|
| `AUR_SSH_PRIVATE_KEY` | SSH key for pushing to AUR git repos | SSH key registered with your AUR account |
| `AUR_EMAIL` | Git commit author email for AUR commits | Your AUR account email |

Needs to track #33