### PR TITLE
Reproducible builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  SOURCE_DATE_EPOCH: 0  # overridden per-step after checkout
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Job 1 – Build matrix
@@ -40,6 +41,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set SOURCE_DATE_EPOCH from git
+        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> "$GITHUB_ENV"
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -56,6 +60,9 @@ jobs:
 
       - name: Build
         run: cargo build --release
+
+      - name: SHA-256 hashes
+        run: sha256sum target/release/fips target/release/fipsctl target/release/fipstop
 
       # Upload the Linux binary so integration jobs can use it without rebuilding
       - name: Upload Linux binary
@@ -81,6 +88,9 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set SOURCE_DATE_EPOCH from git
+        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> "$GITHUB_ENV"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/package-openwrt.yml
+++ b/.github/workflows/package-openwrt.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  SOURCE_DATE_EPOCH: 0  # overridden per-step after checkout
 
 jobs:
   build:
@@ -45,6 +46,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Set SOURCE_DATE_EPOCH from git
+        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> "$GITHUB_ENV"
 
       - name: Derive package version
         id: version
@@ -84,7 +88,7 @@ jobs:
             openwrt-${{ matrix.rust_target }}-
 
       - name: Install cargo-zigbuild
-        run: cargo install cargo-zigbuild --locked
+        run: cargo install cargo-zigbuild --version 0.19.8 --locked
 
       - name: Install zig (required by cargo-zigbuild)
         uses: goto-bus-stop/setup-zig@v2
@@ -97,6 +101,13 @@ jobs:
           PKG_VERSION: ${{ steps.version.outputs.version }}
           LLVM_STRIP: llvm-strip
         run: ./packaging/openwrt-ipk/build-ipk.sh --arch ${{ matrix.build_arch }}
+
+      - name: SHA-256 hashes
+        run: |
+          echo "==> Binaries:"
+          sha256sum target/${{ matrix.rust_target }}/release/fips target/${{ matrix.rust_target }}/release/fipsctl target/${{ matrix.rust_target }}/release/fipstop
+          echo "==> Package:"
+          sha256sum dist/${{ steps.version.outputs.filename }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -19,6 +19,11 @@ if ! command -v cargo-deb &>/dev/null; then
     exit 1
 fi
 
+# Derive SOURCE_DATE_EPOCH from git if not already set (reproducible builds)
+if [ -z "${SOURCE_DATE_EPOCH:-}" ]; then
+    export SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
+fi
+
 # Build the .deb package
 echo "Building .deb package..."
 cargo deb

--- a/packaging/openwrt-ipk/build-ipk.sh
+++ b/packaging/openwrt-ipk/build-ipk.sh
@@ -244,7 +244,11 @@ fi
 ipk_tar() {
     # ipk_tar <output.tar.gz> <source-dir> [paths...]
     local out="$1" src="$2"; shift 2
-    COPYFILE_DISABLE=1 "$TAR_CMD" $TAR_EXTRA_FLAGS -czf "$out" -C "$src" "$@"
+    local mtime_flags=""
+    if [ -n "${SOURCE_DATE_EPOCH:-}" ]; then
+        mtime_flags="--mtime=@$SOURCE_DATE_EPOCH"
+    fi
+    COPYFILE_DISABLE=1 "$TAR_CMD" $TAR_EXTRA_FLAGS $mtime_flags -czf "$out" -C "$src" "$@"
 }
 
 ipk_tar "$IPK_WORK/control.tar.gz" "$CONTROL_DIR" .

--- a/packaging/systemd/build-tarball.sh
+++ b/packaging/systemd/build-tarball.sh
@@ -45,9 +45,16 @@ cp "${SCRIPT_DIR}/README.install.md" "${STAGING_DIR}/"
 
 chmod +x "${STAGING_DIR}/install.sh" "${STAGING_DIR}/uninstall.sh"
 
-# Create tarball
+# Create tarball (reproducible: normalize timestamps and ownership)
 cd "${DEPLOY_DIR}"
-tar czf "${TARBALL_NAME}.tar.gz" "${TARBALL_NAME}/"
+TAR_REPRO_FLAGS=""
+if [ -n "${SOURCE_DATE_EPOCH:-}" ]; then
+    TAR_REPRO_FLAGS="--mtime=@${SOURCE_DATE_EPOCH}"
+fi
+if tar --version 2>/dev/null | grep -q 'GNU tar'; then
+    TAR_REPRO_FLAGS="${TAR_REPRO_FLAGS} --numeric-owner --owner=0 --group=0"
+fi
+COPYFILE_DISABLE=1 tar ${TAR_REPRO_FLAGS} -czf "${TARBALL_NAME}.tar.gz" "${TARBALL_NAME}/"
 rm -rf "${STAGING_DIR}"
 
 echo ""

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.94.0"


### PR DESCRIPTION
## Reproducible Builds

Make builds deterministic so that two independent builds from the same commit produce byte-identical output.

### Changes

- **Pin Rust toolchain** (`rust-toolchain.toml`) — locks to 1.94.0 across all environments, preventing silent codegen drift from Rust updates
- **Thread `SOURCE_DATE_EPOCH` through CI** — both `ci.yml` and `package-openwrt.yml` derive the timestamp from the git commit (`git log -1 --format=%ct`), eliminating build-time clock dependency
- **Normalize tar archives** — `build-ipk.sh` and `build-tarball.sh` now pass `--mtime=@$SOURCE_DATE_EPOCH` (and `--numeric-owner --owner=0 --group=0` on GNU tar) for deterministic archive metadata
- **Deb packaging** — `build-deb.sh` derives `SOURCE_DATE_EPOCH` from git when not set; `cargo-deb` respects it natively
- **Pin `cargo-zigbuild`** to 0.19.8 in OpenWrt CI to prevent packaging metadata drift
- **SHA-256 hash output** — both CI workflows now print binary hashes (and .ipk hash in the OpenWrt workflow) for verification

### What was already in place

Cargo.lock, musl static linking, GNU/BSD tar detection, `COPYFILE_DISABLE=1`, and `llvm-strip` were already handling the hard parts. This PR closes the remaining gaps in packaging metadata and toolchain pinning.

### Verification

Compare SHA-256 output between two CI runs on the same commit — hashes should match.
