### PR TITLE
Update fips-intro.md

### DIFF
--- a/docs/design/fips-intro.md
+++ b/docs/design/fips-intro.md
@@ -708,7 +708,7 @@ Ethernet, Bluetooth, radio, serial — through a uniform transport abstraction.
 Several mesh overlays have demonstrated transport-agnostic design:
 [CJDNS](https://github.com/cjdelisle/cjdns) runs over UDP and Ethernet,
 [Yggdrasil](https://yggdrasil-network.github.io/) supports TCP and TLS
-transports, and [Tor](https://www.torproject.org/) can use pluggable
+transport but has IPv6 link-local discovery and therefore is zeroconf, and [Tor](https://www.torproject.org/) can use pluggable
 transports to tunnel through various media. FIPS extends this pattern to
 shared-medium transports (radio, BLE) with per-transport MTU and discovery
 capabilities.


### PR DESCRIPTION
Thought I should correct this. Yggdrasil is zeroconf on any standard Linux (and Mac) machine.

Probably Windows too.

If you have normal setup, you have IPv6 link-local and if you have that you can do multicast discovery. So I want to fix that.