### PR TITLE
Fix OpenWrt ipk build: exclude BLE feature that requires D-Bus

### DIFF
--- a/packaging/openwrt-ipk/build-ipk.sh
+++ b/packaging/openwrt-ipk/build-ipk.sh
@@ -109,6 +109,8 @@ cd "$PROJECT_ROOT"
 cargo zigbuild \
     --release \
     --target "$RUST_TARGET" \
+    --no-default-features \
+    --features tui \
     --bin fips \
     --bin fipsctl \
     --bin fipstop


### PR DESCRIPTION
The ble feature (bluer crate) pulls in libdbus-sys which cannot cross-compile with cargo-zigbuild. Disable default features and explicitly enable only tui for the OpenWrt package build.