### PR TITLE
doc: improve contributor setup guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,17 +2,64 @@
 
 ## Getting Started
 
-Clone the repo and verify your setup:
+Clone the repo:
 
 ```
 git clone https://github.com/jmcorgan/fips.git
 cd fips
-cargo build
-cargo test
 ```
 
-Read [docs/design/](docs/design/) for protocol understanding, starting with
-[fips-intro.md](docs/design/fips-intro.md).
+Before changing code, read the protocol docs in this order:
+
+- [docs/design/README.md](docs/design/README.md)
+- [docs/design/fips-intro.md](docs/design/fips-intro.md)
+- the specific design doc for the behavior you are touching
+
+## Prerequisites
+
+- Rust 1.85+ and Linux with TUN support
+- For the default BLE-enabled build on Debian/Ubuntu:
+  `sudo apt install bluez libdbus-1-dev pkg-config`
+- Docker is required for the integration harnesses under [testing/](testing/)
+
+If you do not want BLE locally, build and test without default features:
+
+```bash
+cargo build --no-default-features --features tui
+cargo test --no-default-features --features tui
+```
+
+## Local Verification
+
+Choose the narrowest check that matches your change:
+
+- Docs-only changes:
+
+```bash
+git diff --check
+```
+
+- Normal code changes:
+
+```bash
+cargo build
+cargo test
+cargo clippy --all -- -D warnings
+```
+
+- Local CI-style unit test run:
+
+```bash
+./testing/ci-local.sh --test-only
+```
+
+- Narrow integration run for transport, routing, Docker, or packaging-sensitive changes:
+
+```bash
+./testing/ci-local.sh --only static-mesh
+```
+
+See [testing/README.md](testing/README.md) for the available integration and chaos harnesses.
 
 ## Filing Issues
 
@@ -22,11 +69,23 @@ Read [docs/design/](docs/design/) for protocol understanding, starting with
 
 ## Pull Requests
 
-- All PRs must pass `cargo build`, `cargo test`, and `cargo clippy` with no
-  warnings.
+- All PRs must pass `cargo build`, `cargo test`, and `cargo clippy --all -- -D warnings`.
 - Keep commits focused — one logical change per commit.
 - Add tests for new functionality.
 - Reference relevant design docs if the change touches protocol behavior.
+- Update docs in the same change when you modify:
+  - protocol or routing behavior
+  - wire formats
+  - configuration shape or defaults
+  - operational workflows or testing instructions
+
+In practice this usually means updating one or more of:
+
+- [docs/design/fips-mesh-operation.md](docs/design/fips-mesh-operation.md)
+- [docs/design/fips-wire-formats.md](docs/design/fips-wire-formats.md)
+- [docs/design/fips-configuration.md](docs/design/fips-configuration.md)
+- [README.md](README.md)
+- [testing/README.md](testing/README.md)
 
 ## Questions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,8 @@ Before changing code, read the protocol docs in this order:
 
 ## Prerequisites
 
-- Rust 1.85+ and Linux with TUN support
+- Rust 1.94.0 and Linux with TUN support
+- Use the pinned toolchain from [rust-toolchain.toml](rust-toolchain.toml) for deterministic builds
 - For the default BLE-enabled build on Debian/Ubuntu:
   `sudo apt install bluez libdbus-1-dev pkg-config`
 - Docker is required for the integration harnesses under [testing/](testing/)

--- a/README.md
+++ b/README.md
@@ -232,6 +232,12 @@ Protocol design documentation is in [docs/design/](docs/design/), organized as
 a layered protocol specification. Start with
 [fips-intro.md](docs/design/fips-intro.md) for the full protocol overview.
 
+If you want to contribute, start with:
+
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [docs/design/README.md](docs/design/README.md)
+- [testing/README.md](testing/README.md)
+
 ## Project Structure
 
 ```text


### PR DESCRIPTION
## Summary

- expand `CONTRIBUTING.md` with real contributor prerequisites and a practical local verification ladder
- add explicit guidance for when protocol/config/wire changes should update docs
- add a small contributor routing hint in `README.md` pointing to the design and testing docs

## Why

The repo already has strong protocol design docs and a substantial testing surface, but the public contributor route was still very thin. This patch makes it easier for contributors to understand:

- what they need installed locally
- which checks to run for different change types
- when docs need to be updated alongside code

## Notes

- this is meant to complement PR #8
- I intentionally did not add a tracked `AGENTS.md` here because that surface is already covered by PR #8

## Verification

- `git diff --check`