### PR TITLE
feat: add tun-support feature flag for mobile platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ tokio = { version = "1", features = ["test-util"] }
 [[bin]]
 name = "fipsctl"
 path = "src/bin/fipsctl.rs"
+required-features = ["tun-support"]
 
 [[bin]]
 name = "fipstop"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,10 @@ repository = "https://github.com/jmcorgan/fips"
 readme = "README.md"
 
 [features]
-default = ["tui", "ble"]
+default = ["tui", "ble", "tun-support"]
 tui = ["dep:ratatui"]
 ble = ["dep:bluer"]
+tun-support = ["dep:tun", "dep:rtnetlink"]
 
 [dependencies]
 ratatui = { version = "0.30", optional = true }
@@ -30,9 +31,9 @@ hex = "0.4"
 clap = { version = "4.5", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tun = { version = "0.8.5", features = ["async"] }
+tun = { version = "0.8.5", features = ["async"], optional = true }
 libc = "0.2"
-rtnetlink = "0.20.0"
+rtnetlink = { version = "0.20.0", optional = true }
 tokio = { version = "1", features = ["rt", "macros", "signal", "sync", "net", "time"] }
 futures = "0.3"
 simple-dns = "0.11.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,42 @@ pub mod peer;
 pub mod protocol;
 pub mod transport;
 pub mod tree;
+#[cfg(feature = "tun-support")]
 pub mod upper;
+
+// When tun-support is disabled, provide the config types directly
+// (they're simple serde structs with no platform-specific deps)
+#[cfg(not(feature = "tun-support"))]
+pub mod upper {
+    pub mod config {
+        use serde::{Deserialize, Serialize};
+
+        #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+        pub struct DnsConfig {
+            #[serde(default)]
+            pub enabled: bool,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub bind_addr: Option<String>,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub port: Option<u16>,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub ttl: Option<u32>,
+        }
+
+        #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+        pub struct TunConfig {
+            #[serde(default)]
+            pub enabled: bool,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub name: Option<String>,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub mtu: Option<u16>,
+        }
+    }
+}
+
+#[cfg(not(feature = "tun-support"))]
+pub use upper::config::{DnsConfig, TunConfig};
 
 // Re-export identity types
 pub use identity::{
@@ -27,6 +62,7 @@ pub use identity::{
 
 // Re-export config types
 pub use config::{Config, ConfigError, IdentityConfig, TorConfig, UdpConfig};
+#[cfg(feature = "tun-support")]
 pub use upper::config::{DnsConfig, TunConfig};
 
 // Re-export tree types

--- a/src/node/handlers/discovery.rs
+++ b/src/node/handlers/discovery.rs
@@ -563,6 +563,7 @@ impl Node {
                 failures = failures,
                 "Discovery lookup timed out, destination unreachable"
             );
+            #[cfg(feature = "tun-support")]
             if let Some(packets) = queued {
                 for pkt in &packets {
                     self.send_icmpv6_dest_unreachable(pkt);

--- a/src/node/handlers/rx_loop.rs
+++ b/src/node/handlers/rx_loop.rs
@@ -35,6 +35,7 @@ impl Node {
         // Take the TUN outbound receiver, or create a dummy channel that never
         // produces messages (when TUN is disabled). Holding the sender prevents
         // the channel from closing.
+        #[cfg(feature = "tun-support")]
         let (mut tun_outbound_rx, _tun_guard) = match self.tun_outbound_rx.take() {
             Some(rx) => (rx, None),
             None => {
@@ -42,9 +43,18 @@ impl Node {
                 (rx, Some(tx))
             }
         };
+        #[cfg(not(feature = "tun-support"))]
+        let (mut tun_outbound_rx, _tun_guard): (
+            tokio::sync::mpsc::Receiver<Vec<u8>>,
+            Option<tokio::sync::mpsc::Sender<Vec<u8>>>,
+        ) = {
+            let (tx, rx) = tokio::sync::mpsc::channel(1);
+            (rx, Some(tx))
+        };
 
         // Take the DNS identity receiver, or create a dummy channel (when DNS
         // is disabled). Same pattern as TUN outbound.
+        #[cfg(feature = "tun-support")]
         let (mut dns_identity_rx, _dns_guard) = match self.dns_identity_rx.take() {
             Some(rx) => (rx, None),
             None => {
@@ -52,30 +62,46 @@ impl Node {
                 (rx, Some(tx))
             }
         };
+        #[cfg(not(feature = "tun-support"))]
+        let (mut dns_identity_rx, _dns_guard): (
+            tokio::sync::mpsc::Receiver<()>,
+            Option<tokio::sync::mpsc::Sender<()>>,
+        ) = {
+            let (tx, rx) = tokio::sync::mpsc::channel(1);
+            (rx, Some(tx))
+        };
 
         let mut tick = tokio::time::interval(Duration::from_secs(self.config.node.tick_interval_secs));
 
-        // Set up control socket channel
-        let (control_tx, mut control_rx) = tokio::sync::mpsc::channel::<
-            crate::control::ControlMessage,
-        >(32);
+        // Set up control channel — use pre-set channel (for embedding) or create
+        // a new one with ControlSocket (for standalone daemon).
+        let mut control_rx = if let Some(rx) = self.control_rx.take() {
+            // In-process embedding: channel was set via set_control_channel()
+            rx
+        } else {
+            // Standalone: create channel and wire up ControlSocket
+            let (control_tx, control_rx) = tokio::sync::mpsc::channel::<
+                crate::control::ControlMessage,
+            >(32);
 
-        if self.config.node.control.enabled {
-            let config = self.config.node.control.clone();
-            let tx = control_tx.clone();
-            tokio::spawn(async move {
-                match ControlSocket::bind(&config) {
-                    Ok(socket) => {
-                        socket.accept_loop(tx).await;
+            if self.config.node.control.enabled {
+                let config = self.config.node.control.clone();
+                let tx = control_tx.clone();
+                tokio::spawn(async move {
+                    match ControlSocket::bind(&config) {
+                        Ok(socket) => {
+                            socket.accept_loop(tx).await;
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "Failed to bind control socket");
+                        }
                     }
-                    Err(e) => {
-                        warn!(error = %e, "Failed to bind control socket");
-                    }
-                }
-            });
-        }
-        // Drop unused sender to avoid keeping channel open if control is disabled
-        drop(control_tx);
+                });
+            }
+            // Drop unused sender to avoid keeping channel open if control is disabled
+            drop(control_tx);
+            control_rx
+        };
 
         info!("RX event loop started");
 
@@ -87,15 +113,29 @@ impl Node {
                         None => break, // channel closed
                     }
                 }
-                Some(ipv6_packet) = tun_outbound_rx.recv() => {
-                    self.handle_tun_outbound(ipv6_packet).await;
+                Some(tun_msg) = tun_outbound_rx.recv() => {
+                    #[cfg(feature = "tun-support")]
+                    {
+                        self.handle_tun_outbound(tun_msg).await;
+                    }
+                    #[cfg(not(feature = "tun-support"))]
+                    {
+                        let _ = tun_msg; // dummy channel, never fires
+                    }
                 }
-                Some(identity) = dns_identity_rx.recv() => {
-                    debug!(
-                        node_addr = %identity.node_addr,
-                        "Registering identity from DNS resolution"
-                    );
-                    self.register_identity(identity.node_addr, identity.pubkey);
+                Some(dns_msg) = dns_identity_rx.recv() => {
+                    #[cfg(feature = "tun-support")]
+                    {
+                        debug!(
+                            node_addr = %dns_msg.node_addr,
+                            "Registering identity from DNS resolution"
+                        );
+                        self.register_identity(dns_msg.node_addr, dns_msg.pubkey);
+                    }
+                    #[cfg(not(feature = "tun-support"))]
+                    {
+                        let _ = dns_msg; // dummy channel, never fires
+                    }
                 }
                 Some((request, response_tx)) = control_rx.recv() => {
                     let response = if request.command.starts_with("show_") {

--- a/src/node/handlers/session.rs
+++ b/src/node/handlers/session.rs
@@ -10,10 +10,12 @@ use crate::node::session_wire::{
     build_fsp_header, fsp_prepend_inner_header, fsp_strip_inner_header,
     parse_encrypted_coords, FspCommonPrefix, FspEncryptedHeader, FSP_COMMON_PREFIX_SIZE,
     FSP_FLAG_CP, FSP_FLAG_K, FSP_HEADER_SIZE, FSP_PHASE_ESTABLISHED, FSP_PHASE_MSG1,
-    FSP_PHASE_MSG2, FSP_PHASE_MSG3, FSP_PORT_HEADER_SIZE, FSP_PORT_IPV6_SHIM,
+    FSP_PHASE_MSG2, FSP_PHASE_MSG3, FSP_PORT_HEADER_SIZE,
 };
+#[cfg(feature = "tun-support")]
+use crate::node::session_wire::FSP_PORT_IPV6_SHIM;
 use crate::protocol::{coords_wire_size, encode_coords};
-use crate::upper::icmp::FIPS_OVERHEAD;
+use crate::protocol::FIPS_OVERHEAD;
 use crate::node::{Node, NodeError};
 use crate::noise::{HandshakeState, XK_HANDSHAKE_MSG1_SIZE, XK_HANDSHAKE_MSG2_SIZE, XK_HANDSHAKE_MSG3_SIZE};
 use crate::mmp::report::ReceiverReport;
@@ -280,6 +282,7 @@ impl Node {
                 let service_payload = &rest[FSP_PORT_HEADER_SIZE..];
 
                 match dst_port {
+                    #[cfg(feature = "tun-support")]
                     FSP_PORT_IPV6_SHIM => {
                         use crate::FipsAddress;
                         let src_ipv6 = FipsAddress::from_node_addr(src_addr).to_ipv6().octets();
@@ -1312,6 +1315,7 @@ impl Node {
     ///
     /// Compresses the IPv6 header (format 0x00), then sends via `send_session_data`
     /// with `src_port=256, dst_port=256`.
+    #[cfg(feature = "tun-support")]
     pub(in crate::node) async fn send_ipv6_packet(
         &mut self,
         dest_addr: &NodeAddr,
@@ -1564,6 +1568,7 @@ impl Node {
 
     // === TUN Outbound (Data Plane) ===
 
+    #[cfg(feature = "tun-support")]
     /// Handle an outbound IPv6 packet from the TUN reader.
     ///
     /// Extracts the destination FipsAddress, looks up the NodeAddr and PublicKey
@@ -1638,6 +1643,7 @@ impl Node {
     }
 
     /// Send ICMPv6 Destination Unreachable back through TUN.
+    #[cfg(feature = "tun-support")]
     pub(in crate::node) fn send_icmpv6_dest_unreachable(&self, original_packet: &[u8]) {
         use crate::upper::icmp::{build_dest_unreachable, should_send_icmp_error, DestUnreachableCode};
         use crate::FipsAddress;
@@ -1660,6 +1666,7 @@ impl Node {
     ///
     /// Rate-limited per source address to prevent ICMP floods from
     /// misconfigured applications sending repeated oversized packets.
+    #[cfg(feature = "tun-support")]
     pub(in crate::node) fn send_icmpv6_packet_too_big(&mut self, original_packet: &[u8], mtu: u32) {
         use crate::upper::icmp::build_packet_too_big;
         use std::net::Ipv6Addr;
@@ -1720,15 +1727,23 @@ impl Node {
 
     /// Flush pending packets for a destination whose session just reached Established.
     async fn flush_pending_packets(&mut self, dest_addr: &NodeAddr) {
-        let packets = match self.pending_tun_packets.remove(dest_addr) {
-            Some(q) => q,
-            None => return,
-        };
-        for packet in packets {
-            if let Err(e) = self.send_ipv6_packet(dest_addr, &packet).await {
-                debug!(dest = %self.peer_display_name(dest_addr), error = %e, "Failed to send queued TUN packet");
-                break;
+        #[cfg(feature = "tun-support")]
+        {
+            let packets = match self.pending_tun_packets.remove(dest_addr) {
+                Some(q) => q,
+                None => return,
+            };
+            for packet in packets {
+                if let Err(e) = self.send_ipv6_packet(dest_addr, &packet).await {
+                    debug!(dest = %self.peer_display_name(dest_addr), error = %e, "Failed to send queued TUN packet");
+                    break;
+                }
             }
+        }
+        #[cfg(not(feature = "tun-support"))]
+        {
+            // No TUN — just drain and discard any queued packets
+            self.pending_tun_packets.remove(dest_addr);
         }
     }
 

--- a/src/node/lifecycle.rs
+++ b/src/node/lifecycle.rs
@@ -4,9 +4,11 @@ use super::{Node, NodeError, NodeState};
 use crate::peer::PeerConnection;
 use crate::protocol::{Disconnect, DisconnectReason};
 use crate::transport::{packet_channel, Link, LinkDirection, LinkId, TransportAddr, TransportId};
+#[cfg(feature = "tun-support")]
 use crate::upper::tun::{run_tun_reader, shutdown_tun_interface, TunDevice, TunState};
 use crate::node::wire::build_msg1;
 use crate::{NodeAddr, PeerIdentity};
+#[cfg(feature = "tun-support")]
 use std::thread;
 use std::time::Duration;
 use tracing::{debug, info, warn};
@@ -566,80 +568,86 @@ impl Node {
         // This allows handshake messages to be sent before we start accepting packets
         self.initiate_peer_connections().await;
 
-        // Initialize TUN interface last, after transports and peers are ready
-        if self.config.tun.enabled {
-            let address = *self.identity.address();
-            match TunDevice::create(&self.config.tun, address).await {
-                Ok(device) => {
-                    let mtu = device.mtu();
-                    let name = device.name().to_string();
-                    let our_addr = *device.address();
+        #[cfg(feature = "tun-support")]
+        {
+            // Initialize TUN interface last, after transports and peers are ready
+            if self.config.tun.enabled {
+                let address = *self.identity.address();
+                match TunDevice::create(&self.config.tun, address).await {
+                    Ok(device) => {
+                        let mtu = device.mtu();
+                        let name = device.name().to_string();
+                        let our_addr = *device.address();
 
-                    info!("TUN device active:");
-                    info!("     name: {}", name);
-                    info!("  address: {}", device.address());
-                    info!("      mtu: {}", mtu);
+                        info!("TUN device active:");
+                        info!("     name: {}", name);
+                        info!("  address: {}", device.address());
+                        info!("      mtu: {}", mtu);
 
-                    // Calculate max MSS for TCP clamping
-                    let effective_mtu = self.effective_ipv6_mtu();
-                    let max_mss = effective_mtu.saturating_sub(40).saturating_sub(20); // IPv6 + TCP headers
-                    
-                    info!("effective MTU: {} bytes", effective_mtu);
-                    debug!("   max TCP MSS: {} bytes", max_mss);
+                        // Calculate max MSS for TCP clamping
+                        let effective_mtu = self.effective_ipv6_mtu();
+                        let max_mss = effective_mtu.saturating_sub(40).saturating_sub(20); // IPv6 + TCP headers
 
-                    // Create writer (dups the fd for independent write access)
-                    let (writer, tun_tx) = device.create_writer(max_mss)?;
+                        info!("effective MTU: {} bytes", effective_mtu);
+                        debug!("   max TCP MSS: {} bytes", max_mss);
 
-                    // Spawn writer thread
-                    let writer_handle = thread::spawn(move || {
-                        writer.run();
-                    });
+                        // Create writer (dups the fd for independent write access)
+                        let (writer, tun_tx) = device.create_writer(max_mss)?;
 
-                    // Clone tun_tx for the reader
-                    let reader_tun_tx = tun_tx.clone();
+                        // Spawn writer thread
+                        let writer_handle = thread::spawn(move || {
+                            writer.run();
+                        });
 
-                    // Create outbound channel for TUN reader → Node
-                    let tun_channel_size = self.config.node.buffers.tun_channel;
-                    let (outbound_tx, outbound_rx) = tokio::sync::mpsc::channel(tun_channel_size);
+                        // Clone tun_tx for the reader
+                        let reader_tun_tx = tun_tx.clone();
 
-                    // Spawn reader thread
-                    let transport_mtu = self.transport_mtu();
-                    let reader_handle = thread::spawn(move || {
-                        run_tun_reader(device, mtu, our_addr, reader_tun_tx, outbound_tx, transport_mtu);
-                    });
+                        // Create outbound channel for TUN reader → Node
+                        let tun_channel_size = self.config.node.buffers.tun_channel;
+                        let (outbound_tx, outbound_rx) = tokio::sync::mpsc::channel(tun_channel_size);
 
-                    self.tun_state = TunState::Active;
-                    self.tun_name = Some(name);
-                    self.tun_tx = Some(tun_tx);
-                    self.tun_outbound_rx = Some(outbound_rx);
-                    self.tun_reader_handle = Some(reader_handle);
-                    self.tun_writer_handle = Some(writer_handle);
-                }
-                Err(e) => {
-                    self.tun_state = TunState::Failed;
-                    warn!(error = %e, "Failed to initialize TUN, continuing without it");
+                        // Spawn reader thread
+                        let transport_mtu = self.transport_mtu();
+                        let reader_handle = thread::spawn(move || {
+                            run_tun_reader(device, mtu, our_addr, reader_tun_tx, outbound_tx, transport_mtu);
+                        });
+
+                        self.tun_state = TunState::Active;
+                        self.tun_name = Some(name);
+                        self.tun_tx = Some(tun_tx);
+                        self.tun_outbound_rx = Some(outbound_rx);
+                        self.tun_reader_handle = Some(reader_handle);
+                        self.tun_writer_handle = Some(writer_handle);
+                    }
+                    Err(e) => {
+                        self.tun_state = TunState::Failed;
+                        warn!(error = %e, "Failed to initialize TUN, continuing without it");
+                    }
                 }
             }
         }
 
-        // Initialize DNS responder (independent of TUN)
-        if self.config.dns.enabled {
-            let bind = format!("{}:{}", self.config.dns.bind_addr(), self.config.dns.port());
-            match tokio::net::UdpSocket::bind(&bind).await {
-                Ok(socket) => {
-                    let dns_channel_size = self.config.node.buffers.dns_channel;
-                    let (identity_tx, identity_rx) = tokio::sync::mpsc::channel(dns_channel_size);
-                    let dns_ttl = self.config.dns.ttl();
-                    let base_hosts = crate::upper::hosts::HostMap::from_peer_configs(self.config.peers());
-                    let hosts_path = std::path::PathBuf::from(crate::upper::hosts::DEFAULT_HOSTS_PATH);
-                    let reloader = crate::upper::hosts::HostMapReloader::new(base_hosts, hosts_path);
-                    info!(bind = %bind, hosts = reloader.hosts().len(), "DNS responder started for .fips domain (auto-reload enabled)");
-                    let handle = tokio::spawn(crate::upper::dns::run_dns_responder(socket, identity_tx, dns_ttl, reloader));
-                    self.dns_identity_rx = Some(identity_rx);
-                    self.dns_task = Some(handle);
-                }
-                Err(e) => {
-                    warn!(bind = %bind, error = %e, "Failed to start DNS responder");
+        #[cfg(feature = "tun-support")]
+        {
+            // Initialize DNS responder (independent of TUN)
+            if self.config.dns.enabled {
+                let bind = format!("{}:{}", self.config.dns.bind_addr(), self.config.dns.port());
+                match tokio::net::UdpSocket::bind(&bind).await {
+                    Ok(socket) => {
+                        let dns_channel_size = self.config.node.buffers.dns_channel;
+                        let (identity_tx, identity_rx) = tokio::sync::mpsc::channel(dns_channel_size);
+                        let dns_ttl = self.config.dns.ttl();
+                        let base_hosts = crate::upper::hosts::HostMap::from_peer_configs(self.config.peers());
+                        let hosts_path = std::path::PathBuf::from(crate::upper::hosts::DEFAULT_HOSTS_PATH);
+                        let reloader = crate::upper::hosts::HostMapReloader::new(base_hosts, hosts_path);
+                        info!(bind = %bind, hosts = reloader.hosts().len(), "DNS responder started for .fips domain (auto-reload enabled)");
+                        let handle = tokio::spawn(crate::upper::dns::run_dns_responder(socket, identity_tx, dns_ttl, reloader));
+                        self.dns_identity_rx = Some(identity_rx);
+                        self.dns_task = Some(handle);
+                    }
+                    Err(e) => {
+                        warn!(bind = %bind, error = %e, "Failed to start DNS responder");
+                    }
                 }
             }
         }
@@ -663,10 +671,13 @@ impl Node {
         self.state = NodeState::Stopping;
         info!(state = %self.state, "Node stopping");
 
-        // Stop DNS responder
-        if let Some(handle) = self.dns_task.take() {
-            handle.abort();
-            debug!("DNS responder stopped");
+        #[cfg(feature = "tun-support")]
+        {
+            // Stop DNS responder
+            if let Some(handle) = self.dns_task.take() {
+                handle.abort();
+                debug!("DNS responder stopped");
+            }
         }
 
         // Send disconnect notifications to all active peers before closing transports
@@ -697,27 +708,30 @@ impl Node {
         self.packet_tx.take();
         self.packet_rx.take();
 
-        // Shutdown TUN interface
-        if let Some(name) = self.tun_name.take() {
-            info!(name = %name, "Shutting down TUN interface");
+        #[cfg(feature = "tun-support")]
+        {
+            // Shutdown TUN interface
+            if let Some(name) = self.tun_name.take() {
+                info!(name = %name, "Shutting down TUN interface");
 
-            // Drop the tun_tx to signal the writer to stop
-            self.tun_tx.take();
+                // Drop the tun_tx to signal the writer to stop
+                self.tun_tx.take();
 
-            // Delete the interface (causes reader to get EFAULT)
-            if let Err(e) = shutdown_tun_interface(&name).await {
-                warn!(name = %name, error = %e, "Failed to shutdown TUN interface");
+                // Delete the interface (causes reader to get EFAULT)
+                if let Err(e) = shutdown_tun_interface(&name).await {
+                    warn!(name = %name, error = %e, "Failed to shutdown TUN interface");
+                }
+
+                // Wait for threads to finish
+                if let Some(handle) = self.tun_reader_handle.take() {
+                    let _ = handle.join();
+                }
+                if let Some(handle) = self.tun_writer_handle.take() {
+                    let _ = handle.join();
+                }
+
+                self.tun_state = TunState::Disabled;
             }
-
-            // Wait for threads to finish
-            if let Some(handle) = self.tun_reader_handle.take() {
-                let _ = handle.join();
-            }
-            if let Some(handle) = self.tun_writer_handle.take() {
-                let _ = handle.join();
-            }
-
-            self.tun_state = TunState::Disabled;
         }
 
         self.state = NodeState::Stopped;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -36,9 +36,19 @@ use crate::transport::tor::TorTransport;
 #[cfg(target_os = "linux")]
 use crate::transport::ethernet::EthernetTransport;
 use crate::tree::TreeState;
+#[cfg(feature = "tun-support")]
 use crate::upper::hosts::HostMap;
+#[cfg(feature = "tun-support")]
 use crate::upper::icmp_rate_limit::IcmpRateLimiter;
+#[cfg(feature = "tun-support")]
 use crate::upper::tun::{TunError, TunOutboundRx, TunState, TunTx};
+
+#[cfg(not(feature = "tun-support"))]
+pub(crate) type TunOutboundRx = tokio::sync::mpsc::Receiver<Vec<u8>>;
+#[cfg(not(feature = "tun-support"))]
+pub(crate) type TunTx = tokio::sync::mpsc::Sender<Vec<u8>>;
+#[cfg(not(feature = "tun-support"))]
+type TunState = &'static str;
 use self::wire::{build_encrypted, build_established_header, prepend_inner_header, FLAG_CE, FLAG_KEY_EPOCH, FLAG_SP};
 use crate::{Config, ConfigError, Identity, IdentityError, NodeAddr, PeerIdentity};
 use rand::Rng;
@@ -114,6 +124,7 @@ pub enum NodeError {
     #[error("identity error: {0}")]
     Identity(#[from] IdentityError),
 
+    #[cfg(feature = "tun-support")]
     #[error("TUN error: {0}")]
     Tun(#[from] TunError),
 
@@ -303,6 +314,11 @@ pub struct Node {
     /// Packet receiver (for event loop).
     packet_rx: Option<PacketRx>,
 
+    // === Control Channel ===
+    /// Pre-set control channel receiver for in-process embedding.
+    /// When set, run_rx_loop uses this instead of creating its own.
+    control_rx: Option<tokio::sync::mpsc::Receiver<crate::control::ControlMessage>>,
+
     // === Connections (Handshake Phase) ===
     /// Pending connections (handshake in progress).
     /// Indexed by LinkId since we don't know the peer's identity yet.
@@ -353,22 +369,30 @@ pub struct Node {
 
     // === TUN Interface ===
     /// TUN device state.
+    #[cfg(feature = "tun-support")]
     tun_state: TunState,
     /// TUN interface name (for cleanup).
+    #[cfg(feature = "tun-support")]
     tun_name: Option<String>,
     /// TUN packet sender channel.
+    #[cfg(feature = "tun-support")]
     tun_tx: Option<TunTx>,
     /// Receiver for outbound packets from the TUN reader.
+    #[cfg(feature = "tun-support")]
     tun_outbound_rx: Option<TunOutboundRx>,
     /// TUN reader thread handle.
+    #[cfg(feature = "tun-support")]
     tun_reader_handle: Option<JoinHandle<()>>,
     /// TUN writer thread handle.
+    #[cfg(feature = "tun-support")]
     tun_writer_handle: Option<JoinHandle<()>>,
 
     // === DNS Responder ===
     /// Receiver for resolved identities from the DNS responder.
+    #[cfg(feature = "tun-support")]
     dns_identity_rx: Option<crate::upper::dns::DnsIdentityRx>,
     /// DNS responder task handle.
+    #[cfg(feature = "tun-support")]
     dns_task: Option<tokio::task::JoinHandle<()>>,
 
     // === Index-Based Session Dispatch ===
@@ -385,6 +409,7 @@ pub struct Node {
     /// Rate limiter for msg1 processing (DoS protection).
     msg1_rate_limiter: HandshakeRateLimiter,
     /// Rate limiter for ICMP Packet Too Big messages.
+    #[cfg(feature = "tun-support")]
     icmp_rate_limiter: IcmpRateLimiter,
     /// Rate limiter for routing error signals (CoordsRequired / PathBroken).
     routing_error_rate_limiter: RoutingErrorRateLimiter,
@@ -431,6 +456,7 @@ pub struct Node {
     // === Host Map ===
     /// Static hostname → npub mapping for DNS resolution.
     /// Built at construction from peer aliases and /etc/fips/hosts.
+    #[cfg(feature = "tun-support")]
     host_map: Arc<HostMap>,
 }
 
@@ -451,6 +477,7 @@ impl Node {
         };
         bloom_state.set_update_debounce_ms(config.node.bloom.update_debounce_ms);
 
+        #[cfg(feature = "tun-support")]
         let tun_state = if config.tun.enabled {
             TunState::Configured
         } else {
@@ -488,12 +515,15 @@ impl Node {
         let backoff_max_secs = config.node.discovery.backoff_max_secs;
         let forward_min_interval_secs = config.node.discovery.forward_min_interval_secs;
 
-        let mut host_map = HostMap::from_peer_configs(config.peers());
-        let hosts_file = HostMap::load_hosts_file(std::path::Path::new(
-            crate::upper::hosts::DEFAULT_HOSTS_PATH,
-        ));
-        host_map.merge(hosts_file);
-        let host_map = Arc::new(host_map);
+        #[cfg(feature = "tun-support")]
+        let host_map = {
+            let mut hm = HostMap::from_peer_configs(config.peers());
+            let hosts_file = HostMap::load_hosts_file(std::path::Path::new(
+                crate::upper::hosts::DEFAULT_HOSTS_PATH,
+            ));
+            hm.merge(hosts_file);
+            Arc::new(hm)
+        };
 
         Ok(Self {
             identity,
@@ -524,18 +554,27 @@ impl Node {
             next_link_id: 1,
             next_transport_id: 1,
             stats: stats::NodeStats::new(),
+            #[cfg(feature = "tun-support")]
             tun_state,
+            #[cfg(feature = "tun-support")]
             tun_name: None,
+            #[cfg(feature = "tun-support")]
             tun_tx: None,
+            #[cfg(feature = "tun-support")]
             tun_outbound_rx: None,
+            #[cfg(feature = "tun-support")]
             tun_reader_handle: None,
+            #[cfg(feature = "tun-support")]
             tun_writer_handle: None,
+            #[cfg(feature = "tun-support")]
             dns_identity_rx: None,
+            #[cfg(feature = "tun-support")]
             dns_task: None,
             index_allocator: IndexAllocator::new(),
             peers_by_index: HashMap::new(),
             pending_outbound: HashMap::new(),
             msg1_rate_limiter,
+            #[cfg(feature = "tun-support")]
             icmp_rate_limiter: IcmpRateLimiter::new(),
             routing_error_rate_limiter: RoutingErrorRateLimiter::new(),
             coords_response_rate_limiter: RoutingErrorRateLimiter::with_interval(
@@ -555,7 +594,9 @@ impl Node {
             estimated_mesh_size: None,
             last_mesh_size_log: None,
             peer_aliases: HashMap::new(),
+            #[cfg(feature = "tun-support")]
             host_map,
+            control_rx: None,
         })
     }
 
@@ -566,6 +607,7 @@ impl Node {
         let mut startup_epoch = [0u8; 8];
         rand::rng().fill_bytes(&mut startup_epoch);
 
+        #[cfg(feature = "tun-support")]
         let tun_state = if config.tun.enabled {
             TunState::Configured
         } else {
@@ -603,6 +645,7 @@ impl Node {
         let max_links = config.node.limits.max_links;
         let coords_response_interval_ms = config.node.session.coords_response_interval_ms;
 
+        #[cfg(feature = "tun-support")]
         let host_map = Arc::new(HostMap::new());
 
         Self {
@@ -634,18 +677,27 @@ impl Node {
             next_link_id: 1,
             next_transport_id: 1,
             stats: stats::NodeStats::new(),
+            #[cfg(feature = "tun-support")]
             tun_state,
+            #[cfg(feature = "tun-support")]
             tun_name: None,
+            #[cfg(feature = "tun-support")]
             tun_tx: None,
+            #[cfg(feature = "tun-support")]
             tun_outbound_rx: None,
+            #[cfg(feature = "tun-support")]
             tun_reader_handle: None,
+            #[cfg(feature = "tun-support")]
             tun_writer_handle: None,
+            #[cfg(feature = "tun-support")]
             dns_identity_rx: None,
+            #[cfg(feature = "tun-support")]
             dns_task: None,
             index_allocator: IndexAllocator::new(),
             peers_by_index: HashMap::new(),
             pending_outbound: HashMap::new(),
             msg1_rate_limiter,
+            #[cfg(feature = "tun-support")]
             icmp_rate_limiter: IcmpRateLimiter::new(),
             routing_error_rate_limiter: RoutingErrorRateLimiter::new(),
             coords_response_rate_limiter: RoutingErrorRateLimiter::with_interval(
@@ -660,7 +712,9 @@ impl Node {
             estimated_mesh_size: None,
             last_mesh_size_log: None,
             peer_aliases: HashMap::new(),
+            #[cfg(feature = "tun-support")]
             host_map,
+            control_rx: None,
         }
     }
 
@@ -913,6 +967,7 @@ impl Node {
     /// 4. Session endpoint's short npub (end-to-end, may not be direct peer)
     /// 5. Truncated NodeAddr hex (unknown address)
     pub(crate) fn peer_display_name(&self, addr: &NodeAddr) -> String {
+        #[cfg(feature = "tun-support")]
         if let Some(hostname) = self.host_map.lookup_hostname(addr) {
             return hostname.to_string();
         }
@@ -1108,15 +1163,26 @@ impl Node {
     // === TUN Interface ===
 
     /// Get the TUN state.
+    #[cfg(feature = "tun-support")]
     pub fn tun_state(&self) -> TunState {
         self.tun_state
     }
 
     /// Get the TUN interface name, if active.
+    #[cfg(feature = "tun-support")]
     pub fn tun_name(&self) -> Option<&str> {
         self.tun_name.as_deref()
     }
 
+    #[cfg(not(feature = "tun-support"))]
+    pub fn tun_state(&self) -> &str {
+        "disabled"
+    }
+
+    #[cfg(not(feature = "tun-support"))]
+    pub fn tun_name(&self) -> Option<&str> {
+        None
+    }
 
     // === Resource Limits ===
 
@@ -1184,6 +1250,20 @@ impl Node {
     /// Get the packet receiver for the event loop.
     pub fn packet_rx(&mut self) -> Option<&mut PacketRx> {
         self.packet_rx.as_mut()
+    }
+
+    /// Set up an in-process control channel for embedding.
+    ///
+    /// Returns a sender for submitting queries/commands.
+    /// The receiver is consumed by `run_rx_loop()`.
+    /// If not called, `run_rx_loop()` creates its own channel
+    /// connected to a ControlSocket (Unix domain socket).
+    pub fn set_control_channel(
+        &mut self,
+    ) -> tokio::sync::mpsc::Sender<crate::control::ControlMessage> {
+        let (tx, rx) = tokio::sync::mpsc::channel(32);
+        self.control_rx = Some(rx);
+        tx
     }
 
     // === Link Management ===
@@ -1550,6 +1630,7 @@ impl Node {
     /// Get the TUN packet sender channel.
     ///
     /// Returns None if TUN is not active or the node hasn't been started.
+    #[cfg(feature = "tun-support")]
     pub fn tun_tx(&self) -> Option<&TunTx> {
         self.tun_tx.as_ref()
     }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -996,8 +996,15 @@ impl Node {
     /// Delegates to `upper::icmp::effective_ipv6_mtu()` with this node's
     /// transport MTU. Returns the maximum IPv6 packet size (including
     /// IPv6 header) that can be transmitted through the FIPS mesh.
+    #[cfg(feature = "tun-support")]
     pub fn effective_ipv6_mtu(&self) -> u16 {
         crate::upper::icmp::effective_ipv6_mtu(self.transport_mtu())
+    }
+
+    /// When TUN support is disabled, return 0 (no IPv6 transport).
+    #[cfg(not(feature = "tun-support"))]
+    pub fn effective_ipv6_mtu(&self) -> u16 {
+        0
     }
 
     /// Get the transport MTU for a specific transport.

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -47,6 +47,13 @@ pub(crate) use session::{coords_wire_size, decode_optional_coords, encode_coords
 /// Protocol version for message compatibility.
 pub const PROTOCOL_VERSION: u8 = 1;
 
+/// FIPS wire overhead in bytes.
+///
+/// 16 (outer header) + 16 (MAC) + 5 (inner header)
+/// + 35 (coords worst case) + 12 (session header)
+/// + 6 (port+format+residual) + 16 (AEAD tag) = 106
+pub const FIPS_OVERHEAD: u16 = 106;
+
 // Legacy type alias re-export
 #[allow(deprecated)]
 pub use link::MessageType;


### PR DESCRIPTION
## Summary
- Add `tun-support` feature flag to make TUN/DNS/ICMP/rtnetlink dependencies optional
- Gate TUN/DNS initialization, cleanup, and rx_loop arms behind the feature flag
- Enable building fips for mobile platforms (Android/iOS) that don't support TUN interfaces

## Test plan
- [ ] Verify build with `tun-support` enabled (default, existing behavior)
- [ ] Verify build without `tun-support` for mobile targets
- [ ] Review gated code paths for correctness

> Draft PR for visual diff review — not ready for merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)