### PR TITLE
Switch std::atomic to portable_atomic for mips support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,6 +985,7 @@ dependencies = [
  "hex",
  "hkdf",
  "libc",
+ "portable-atomic",
  "rand 0.10.0",
  "ratatui",
  "rtnetlink",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ futures = "0.3"
 simple-dns = "0.11.2"
 socket2 = { version = "0.6.2", features = ["all"] }
 tokio-socks = "0.5"
+portable-atomic = { version = "1", features = ["std"] }
 
 rustables = { version = "0.8.7", optional = true }
 

--- a/src/transport/ble/stats.rs
+++ b/src/transport/ble/stats.rs
@@ -1,6 +1,6 @@
 //! BLE transport statistics.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use portable_atomic::{AtomicU64, Ordering};
 
 use serde::Serialize;
 

--- a/src/transport/ethernet/stats.rs
+++ b/src/transport/ethernet/stats.rs
@@ -1,6 +1,6 @@
 //! Ethernet transport statistics.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use portable_atomic::{AtomicU64, Ordering};
 
 /// Statistics for an Ethernet transport instance.
 ///

--- a/src/transport/tcp/stats.rs
+++ b/src/transport/tcp/stats.rs
@@ -1,6 +1,6 @@
 //! TCP transport statistics.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use portable_atomic::{AtomicU64, Ordering};
 
 use serde::Serialize;
 

--- a/src/transport/tor/stats.rs
+++ b/src/transport/tor/stats.rs
@@ -1,6 +1,6 @@
 //! Tor transport statistics.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use portable_atomic::{AtomicU64, Ordering};
 
 use serde::Serialize;
 

--- a/src/transport/udp/stats.rs
+++ b/src/transport/udp/stats.rs
@@ -1,6 +1,6 @@
 //! UDP transport statistics.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use portable_atomic::{AtomicU64, Ordering};
 
 use serde::Serialize;
 


### PR DESCRIPTION
A simple change switch atomic to portable_atomic to support mips targets. A quick compile and test run on x86_64 and mips seems to run fine.