### PR TITLE
Arch packaging fix (aur): fix namcap issues in PKGBUILD

### DIFF
--- a/packaging/aur/PKGBUILD-git
+++ b/packaging/aur/PKGBUILD-git
@@ -1,6 +1,6 @@
 # Maintainer: Johnathan Corgan <jcorgan@corganlabs.com>
 pkgname=fips-git
-pkgver=0.2.0.rel.r41.g1e4f375
+pkgver=0
 pkgrel=1
 pkgdesc="Distributed, decentralized network routing protocol for mesh nodes"
 url="https://github.com/jmcorgan/fips"
@@ -58,7 +58,7 @@ package() {
     install -Dm0644 packaging/debian/fips-dns.service "$pkgdir/usr/lib/systemd/system/fips-dns.service"
 
     # Config files (from packaging/common/)
-    install -Dm0644 packaging/common/fips.yaml "$pkgdir/etc/fips/fips.yaml"
+    install -Dm0600 packaging/common/fips.yaml "$pkgdir/etc/fips/fips.yaml"
     install -Dm0644 packaging/common/hosts "$pkgdir/etc/fips/hosts"
 
     # System integration (from local source files in $srcdir)

--- a/packaging/aur/PKGBUILD-git
+++ b/packaging/aur/PKGBUILD-git
@@ -1,12 +1,12 @@
 # Maintainer: Johnathan Corgan <jcorgan@corganlabs.com>
 pkgname=fips-git
-pkgver=0.1.0.r19.g8c349f5
+pkgver=0.2.0.rel.r41.g1e4f375
 pkgrel=1
 pkgdesc="Distributed, decentralized network routing protocol for mesh nodes"
 url="https://github.com/jmcorgan/fips"
 license=('MIT')
 arch=('x86_64')
-depends=('gcc-libs' 'glibc')
+depends=('dbus' 'gcc-libs' 'glibc')
 makedepends=('cargo' 'git')
 optdepends=('systemd-resolved: .fips DNS resolution')
 provides=('fips')
@@ -19,7 +19,7 @@ source=("fips::git+https://github.com/jmcorgan/fips.git"
 b2sums=('SKIP'
         '25a0552f3d67d12f48dfd40fe4776ad7c46afeeab76bd2674b48e234db3c145810a24569a8c1a7f4c186eb546f0fae2ebe1550080c0e91d8eb72ba9934c752a6'
         '844257cb8e09cd935d0d6345922d0f3ec777411daca20e24175b346a7b3cb95ebce12631a9466c4d94f1588ed8d62d92514ff24025ccfd0efb358e542b454b00')
-options=('!lto')
+options=('!lto' '!debug')
 
 pkgver() {
     cd fips
@@ -58,7 +58,7 @@ package() {
     install -Dm0644 packaging/debian/fips-dns.service "$pkgdir/usr/lib/systemd/system/fips-dns.service"
 
     # Config files (from packaging/common/)
-    install -Dm0600 packaging/common/fips.yaml "$pkgdir/etc/fips/fips.yaml"
+    install -Dm0644 packaging/common/fips.yaml "$pkgdir/etc/fips/fips.yaml"
     install -Dm0644 packaging/common/hosts "$pkgdir/etc/fips/hosts"
 
     # System integration (from local source files in $srcdir)


### PR DESCRIPTION
Changes made to fix namcap issues:

1. Added `dbus` to dependencies - the fips binary links against libdbus-1.so.3, so dbus must be listed as a runtime dependency.

2. Disabled split debug package - added `!debug` to options to prevent creating a broken -debug package. The debug package was generating symlinks with incorrect paths, causing namcap errors.

3. Made config file world-readable - changed fips.yaml permissions from 0600 to 0644.

Remaining namcap warnings (can be ignored):
- "Unused shared library '/usr/lib64/ld-linux-x86-64.so.2'" - False positive. The dynamic linker is required for the binary to run.
- "Dependency libgcc detected and implicitly satisfied" / "gcc-libs may not be needed" - These are contradictory. The binaries do link to libgcc_s.so.1, and gcc-libs provides it. Keeping an explicit dependency is correct.