### PR TITLE
Fix AUR publish workflow bash --command error

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -22,7 +22,7 @@ jobs:
           sed -i "s/^pkgver=.*/pkgver=${VERSION}/" packaging/aur/PKGBUILD
 
       - name: Publish to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.2
         with:
           pkgname: fips
           pkgbuild: packaging/aur/PKGBUILD


### PR DESCRIPTION
Bump KSXGitHub/github-actions-deploy-aur from v4.1.1 to v4.1.2, which fixes the runuser invocation that caused "bash: --command: invalid option" during SSH initialization.