### PR TITLE
Clarify macOS sidecar naming and fix a keygen bug in sidecar startup  

### DIFF
--- a/examples/wireguard-sidecar-macos/Dockerfile
+++ b/examples/wireguard-sidecar-macos/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends vim wireguard-tools && \
     rm -rf /var/lib/apt/lists/*
 
-COPY entrypoint-gateway.sh /usr/local/bin/entrypoint-gateway.sh
-RUN chmod +x /usr/local/bin/entrypoint-gateway.sh
+COPY entrypoint-sidecar.sh /usr/local/bin/entrypoint-sidecar.sh
+RUN chmod +x /usr/local/bin/entrypoint-sidecar.sh
 
-ENTRYPOINT ["/usr/local/bin/entrypoint-gateway.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint-sidecar.sh"]

--- a/examples/wireguard-sidecar-macos/README.md
+++ b/examples/wireguard-sidecar-macos/README.md
@@ -7,8 +7,8 @@ This example lets macOS reach the FIPS mesh through a local Docker container.
 - `fips-on.sh`: user-facing startup wrapper
 - `fips-host.sh`: small privileged helper for macOS networking
 - `fips-off.sh`: teardown wrapper
-- `entrypoint-gateway.sh`: container startup logic
-- `identity/fips.key` and `identity/fips.pub`: generated persistent gateway identity
+- `entrypoint-sidecar.sh`: container startup logic
+- `identity/fips.key` and `identity/fips.pub`: generated persistent sidecar identity
 - `fips.yaml`: FIPS node config used inside the container
 
 ## Configure Peers
@@ -18,7 +18,7 @@ Before first use, replace the placeholder bootstrap peer in `fips.yaml` with a r
 ## Startup Flow
 
 ```text
-macOS user        fips-on.sh         Docker / fips-gateway       fips-host.sh (sudo)
+macOS user        fips-on.sh      Docker / wireguard-sidecar     fips-host.sh (sudo)
     |                 |                        |                         |
     | ./fips-on.sh    |                        |                         |
     |---------------> |                        |                         |
@@ -45,10 +45,10 @@ macOS user        fips-on.sh         Docker / fips-gateway       fips-host.sh (s
 ## What `fips-on.sh` Does
 
 1. Creates `identity/` and `identity/wireguard/` if needed.
-2. Generates `identity/fips.key` and `identity/fips.pub` with `fipsctl keygen --dir /etc/fips` if the gateway does not already have a persistent identity.
+2. Generates `identity/fips.key` and `identity/fips.pub` with `fipsctl keygen --dir /etc/fips` if the sidecar does not already have a persistent identity.
 3. Generates the host WireGuard client keypair if missing.
 4. Fixes ownership on the generated client key files so the Docker bind mount stays readable on macOS.
-5. Starts `fips-gateway` with `docker compose up -d --build --force-recreate`.
+5. Starts `wireguard-sidecar` with `docker compose up -d --build --force-recreate`.
 6. Waits until the container has created and brought up `wg0`.
 7. Calls the privileged helper to configure host networking:
    - writes `/etc/wireguard/fips0.conf`
@@ -58,7 +58,7 @@ macOS user        fips-on.sh         Docker / fips-gateway       fips-host.sh (s
 
 ## What Happens In The Container
 
-`entrypoint-gateway.sh`:
+`entrypoint-sidecar.sh`:
 
 1. Generates the server WireGuard keypair on first run.
 2. Waits briefly for `identity/wireguard/client.pub` from the host.
@@ -72,23 +72,24 @@ Only FIPS traffic for `fd00::/8` is forwarded through the sidecar. Regular
 internet traffic still uses the macOS host network and does not route through
 `wg0` or `fips0`.
 
-## Gateway FIPS Identity
+## Sidecar FIPS Identity
 
 `fips-on.sh` generates `identity/fips.key` and `identity/fips.pub` on first run by calling:
 
 ```bash
 docker run --rm \
+  --entrypoint fipsctl \
   -v "$PWD/identity:/etc/fips" \
   fips-test:latest \
-  fipsctl keygen --dir /etc/fips
+  keygen --dir /etc/fips
 ```
 
-That key is then bind-mounted into `/etc/fips/fips.key`, so the gateway keeps
+That key is then bind-mounted into `/etc/fips/fips.key`, so the sidecar keeps
 the same FIPS identity even though `fips-on.sh` uses `docker compose up
 --force-recreate`.
 
 Delete `identity/fips.key` if you want the next `./fips-on.sh` run to create a
-fresh gateway identity.
+fresh sidecar identity.
 
 ## Why `sudo` Is Still Needed
 

--- a/examples/wireguard-sidecar-macos/docker-compose.yml
+++ b/examples/wireguard-sidecar-macos/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
-  fips-gateway:
+  wireguard-sidecar:
     build: .
-    image: fips-gateway:latest
-    container_name: fips-gateway
-    hostname: fips-gateway
+    image: wireguard-sidecar:latest
+    container_name: wireguard-sidecar
+    hostname: wireguard-sidecar
     privileged: true
     devices:
       - /dev/net/tun:/dev/net/tun

--- a/examples/wireguard-sidecar-macos/entrypoint-sidecar.sh
+++ b/examples/wireguard-sidecar-macos/entrypoint-sidecar.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Gateway entrypoint: WireGuard tunnel + FIPS daemon.
+# Sidecar entrypoint: WireGuard tunnel + FIPS daemon.
 set -e
 
 CONFIG="/etc/fips/fips.yaml"

--- a/examples/wireguard-sidecar-macos/fips-off.sh
+++ b/examples/wireguard-sidecar-macos/fips-off.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Stop the FIPS gateway and restore macOS network settings.
+# Stop the WireGuard sidecar and restore macOS network settings.
 #
 # Safe to run multiple times (idempotent).
 #
@@ -27,9 +27,9 @@ run_host_helper() {
 
 run_host_helper off
 
-echo "Stopping FIPS gateway container..."
+echo "Stopping WireGuard sidecar container..."
 run_as_real_user docker compose -f "$SCRIPT_DIR/docker-compose.yml" down 2>/dev/null || true
 echo "  Container stopped"
 
 echo ""
-echo "FIPS gateway is OFF. macOS network restored."
+echo "WireGuard sidecar is OFF. macOS network restored."

--- a/examples/wireguard-sidecar-macos/fips-on.sh
+++ b/examples/wireguard-sidecar-macos/fips-on.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Start the FIPS gateway and configure macOS to reach the mesh.
+# Start the WireGuard sidecar and configure macOS to reach the mesh.
 #
 # Sets up:
 #   1. WireGuard tunnel from macOS to the FIPS Docker container
@@ -39,9 +39,10 @@ mkdir -p "$IDENTITY_DIR" "$WG_DIR"
 if [ ! -f "$IDENTITY_DIR/fips.key" ]; then
     echo "Generating FIPS identity keypair..."
     run_as_real_user docker run --rm \
+        --entrypoint fipsctl \
         -v "$IDENTITY_DIR:/etc/fips" \
         fips-test:latest \
-        fipsctl keygen --dir /etc/fips
+        keygen --dir /etc/fips
 fi
 
 # ── 2. Generate WireGuard client keys ─────────────────────────
@@ -59,20 +60,20 @@ fi
 run_host_helper fix-key-perms "$REAL_USER" "$WG_DIR"
 
 # ── 3. Start Docker container ─────────────────────────────────
-echo "Starting FIPS gateway container..."
+echo "Starting WireGuard sidecar container..."
 run_as_real_user docker compose -f "$SCRIPT_DIR/docker-compose.yml" up -d --build --force-recreate
 
 echo "Waiting for container..."
 for i in $(seq 1 30); do
-    if run_as_real_user docker exec fips-gateway wg show wg0 >/dev/null 2>&1; then
+    if run_as_real_user docker exec wireguard-sidecar wg show wg0 >/dev/null 2>&1; then
         break
     fi
     sleep 1
 done
 
-if ! run_as_real_user docker exec fips-gateway wg show wg0 >/dev/null 2>&1; then
+if ! run_as_real_user docker exec wireguard-sidecar wg show wg0 >/dev/null 2>&1; then
     echo "Error: WireGuard not ready in container after 30s"
-    echo "Check: docker logs fips-gateway"
+    echo "Check: docker logs wireguard-sidecar"
     exit 1
 fi
 
@@ -85,7 +86,7 @@ run_host_helper on "$SCRIPT_DIR"
 
 # ── Done ──────────────────────────────────────────────────────
 echo ""
-echo "FIPS gateway is ON."
+echo "WireGuard sidecar is ON."
 echo ""
 echo "  WireGuard:  fips0 tunnel active (fd00::/8 routed)"
 echo "  DNS:        .fips names resolve via localhost:5354"
@@ -93,7 +94,7 @@ echo ""
 echo "Usage:"
 echo "  ping6 -c3 \$(dig +short AAAA your-bootstrap-peer.fips @127.0.0.1 -p 5354)"
 echo ""
-echo "  docker exec fips-gateway fipsctl show status"
-echo "  docker exec fips-gateway fipsctl show peers"
+echo "  docker exec wireguard-sidecar fipsctl show status"
+echo "  docker exec wireguard-sidecar fipsctl show peers"
 echo ""
 echo "To stop: ./fips-off.sh"


### PR DESCRIPTION
## Summary
- rename the macOS WireGuard example container and entrypoint to `wireguard-sidecar` so it is distinct from the repo's real `fips-gateway` binary
- update the example scripts and README to use the new sidecar naming consistently
- override the `fips-test:latest` entrypoint during key generation so `./fips-on.sh` can create `identity/fips.key` before the sidecar container starts