### PR TITLE
Rationalize cargo feature and platform-gate surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Build
-        run: cargo build --release ${{ (runner.os == 'macOS' || runner.os == 'Windows') && '--no-default-features --features tui' || '--features gateway' }}
+        run: cargo build --release
 
       - name: SHA-256 hashes (Linux)
         if: runner.os == 'Linux'
@@ -147,7 +147,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Run unit tests
-        run: cargo nextest run --all --profile ci --features gateway
+        run: cargo nextest run --all --profile ci
 
       - name: Publish test report (Checks tab)
         uses: dorny/test-reporter@v2
@@ -197,7 +197,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Run unit tests
-        run: cargo nextest run --all --profile ci --no-default-features --features tui
+        run: cargo nextest run --all --profile ci
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Job 2c – Unit tests (Windows)
@@ -226,7 +226,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Run unit tests
-        run: cargo nextest run --all --profile ci --no-default-features --features tui
+        run: cargo nextest run --all --profile ci
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Job 3 – Integration tests (static mesh + chaos simulation)

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -90,7 +90,7 @@ jobs:
         run: cargo install cargo-deb --version 3.6.3 --locked
 
       - name: Build release binaries
-        run: cargo build --release --features gateway
+        run: cargo build --release
 
       - name: Build systemd tarball
         env:

--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -86,7 +86,7 @@ jobs:
             macos-release-${{ matrix.arch }}-
 
       - name: Build release binaries
-        run: cargo build --release --target ${{ matrix.target }} --no-default-features --features tui
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Build macOS package
         run: |

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -77,7 +77,7 @@ jobs:
             windows-release-x86_64-
 
       - name: Build release binaries
-        run: cargo build --release --no-default-features --features tui
+        run: cargo build --release
 
       - name: Build Windows package
         shell: pwsh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,10 @@ repository = "https://github.com/jmcorgan/fips"
 readme = "README.md"
 
 [features]
-default = ["tui", "ble"]
-tui = ["dep:ratatui"]
-ble = ["dep:bluer"]
-gateway = ["dep:rustables"]
+default = []
 
 [dependencies]
-ratatui = { version = "0.30", optional = true }
+ratatui = "0.30"
 secp256k1 = { version = "0.30", features = ["rand", "global-context"] }
 sha2 = "0.10"
 hkdf = "0.12"
@@ -38,15 +35,17 @@ socket2 = { version = "0.6.2", features = ["all"] }
 tokio-socks = "0.5"
 portable-atomic = { version = "1", features = ["std"] }
 
-rustables = { version = "0.8.7", optional = true }
-
 [target.'cfg(unix)'.dependencies]
 tun = { version = "0.8.5", features = ["async"] }
 libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = "0.20.0"
-bluer = { version = "0.17", features = ["bluetoothd", "l2cap"], optional = true }
+rustables = "0.8.7"
+
+# bluer/BlueZ needs glibc — see build.rs `bluer_available` cfg gate.
+[target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
+bluer = { version = "0.17", features = ["bluetoothd", "l2cap"] }
 
 [target.'cfg(windows)'.dependencies]
 wintun = "0.5"
@@ -95,9 +94,7 @@ path = "src/bin/fipsctl.rs"
 [[bin]]
 name = "fips-gateway"
 path = "src/bin/fips-gateway.rs"
-required-features = ["gateway"]
 
 [[bin]]
 name = "fipstop"
 path = "src/bin/fipstop/main.rs"
-required-features = ["tui"]

--- a/build.rs
+++ b/build.rs
@@ -36,4 +36,14 @@ fn main() {
 
     // Support reproducible builds (Debian packaging)
     println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+
+    // bluer/BlueZ is glibc-linux only: musl cross-compiles (OpenWrt) can't
+    // satisfy libdbus-sys's pkg-config cross-compile requirement, and musl
+    // router targets don't run BlueZ by default anyway.
+    println!("cargo:rustc-check-cfg=cfg(bluer_available)");
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    if target_os == "linux" && target_env != "musl" {
+        println!("cargo:rustc-cfg=bluer_available");
+    }
 }

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -29,13 +29,13 @@ build() {
     cd "$pkgname-$pkgver"
     export CARGO_TARGET_DIR=target
     export SOURCE_DATE_EPOCH=$(stat -c %Y Cargo.toml)
-    cargo build --frozen --release --features gateway
+    cargo build --frozen --release
 }
 
 check() {
     cd "$pkgname-$pkgver"
     export CARGO_TARGET_DIR=target
-    cargo test --frozen --lib --features gateway
+    cargo test --frozen --lib
 }
 
 package() {

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -71,7 +71,7 @@ echo "Building .deb package..."
 OUTPUT_DIR="$(mktemp -d)"
 trap 'rm -rf "${OUTPUT_DIR}"' EXIT
 
-cargo_args=(deb --output "${OUTPUT_DIR}" --features gateway)
+cargo_args=(deb --output "${OUTPUT_DIR}")
 if [[ -n "${TARGET_TRIPLE}" ]]; then
     cargo_args+=(--target "${TARGET_TRIPLE}")
 fi

--- a/packaging/macos/build-pkg.sh
+++ b/packaging/macos/build-pkg.sh
@@ -72,7 +72,7 @@ echo "Building FIPS v${VERSION} for macOS ${ARCH}..."
 
 # Build release binaries
 if [[ "${NO_BUILD}" -eq 0 ]]; then
-    cargo_args=(build --release --manifest-path="${PROJECT_ROOT}/Cargo.toml" --no-default-features --features tui)
+    cargo_args=(build --release --manifest-path="${PROJECT_ROOT}/Cargo.toml")
     [[ -n "${TARGET_TRIPLE}" ]] && cargo_args+=(--target "${TARGET_TRIPLE}")
     cargo "${cargo_args[@]}"
 fi

--- a/packaging/openwrt-ipk/build-ipk.sh
+++ b/packaging/openwrt-ipk/build-ipk.sh
@@ -109,8 +109,6 @@ cd "$PROJECT_ROOT"
 cargo zigbuild \
     --release \
     --target "$RUST_TARGET" \
-    --no-default-features \
-    --features tui,gateway \
     --bin fips \
     --bin fipsctl \
     --bin fipstop \

--- a/packaging/systemd/build-tarball.sh
+++ b/packaging/systemd/build-tarball.sh
@@ -84,9 +84,9 @@ fi
 
 echo "Building FIPS v${VERSION} for ${ARCH}..."
 
-# Build release binaries (tui is a default feature, includes fipstop)
+# Build release binaries
 if [[ "${NO_BUILD}" -eq 0 ]]; then
-    cargo_args=(build --release --manifest-path="${PROJECT_ROOT}/Cargo.toml" --features gateway)
+    cargo_args=(build --release --manifest-path="${PROJECT_ROOT}/Cargo.toml")
     if [[ -n "${TARGET_TRIPLE}" ]]; then
         cargo_args+=(--target "${TARGET_TRIPLE}")
     fi

--- a/packaging/windows/build-zip.ps1
+++ b/packaging/windows/build-zip.ps1
@@ -38,7 +38,7 @@ Write-Host "Building FIPS v$Version for Windows $Arch..."
 # Build release binaries
 if (-not $NoBuild) {
     Push-Location $ProjectRoot
-    cargo build --release --no-default-features --features tui
+    cargo build --release
     if ($LASTEXITCODE -ne 0) {
         Write-Error "cargo build failed"
         exit 1

--- a/src/bin/fips-gateway.rs
+++ b/src/bin/fips-gateway.rs
@@ -3,21 +3,33 @@
 //! Allows unmodified LAN hosts to reach FIPS mesh destinations via
 //! DNS-allocated virtual IPs and kernel nftables NAT.
 
+#[cfg(target_os = "linux")]
 use clap::Parser;
+#[cfg(target_os = "linux")]
 use fips::Config;
 #[cfg(target_os = "linux")]
 use fips::gateway::{control, dns, nat, net, pool};
+#[cfg(target_os = "linux")]
 use fips::version;
+#[cfg(target_os = "linux")]
 use std::path::PathBuf;
+#[cfg(target_os = "linux")]
 use std::sync::Arc;
+#[cfg(target_os = "linux")]
 use std::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(target_os = "linux")]
 use std::time::Instant;
+#[cfg(target_os = "linux")]
 use tokio::signal::unix::{SignalKind, signal};
+#[cfg(target_os = "linux")]
 use tokio::sync::{Mutex, mpsc, watch};
+#[cfg(target_os = "linux")]
 use tracing::{error, info, warn};
+#[cfg(target_os = "linux")]
 use tracing_subscriber::{EnvFilter, fmt};
 
 /// FIPS outbound LAN gateway
+#[cfg(target_os = "linux")]
 #[derive(Parser, Debug)]
 #[command(
     name = "fips-gateway",
@@ -35,6 +47,13 @@ struct Args {
     log_level: String,
 }
 
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("fips-gateway requires Linux (nftables unavailable on this platform)");
+    std::process::exit(1);
+}
+
+#[cfg(target_os = "linux")]
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     let args = Args::parse();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,7 +18,7 @@
 //!     nsec: "nsec1..."
 //! ```
 
-#[cfg(feature = "gateway")]
+#[cfg(target_os = "linux")]
 mod gateway;
 mod node;
 mod peer;
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
-#[cfg(feature = "gateway")]
+#[cfg(target_os = "linux")]
 pub use gateway::{ConntrackConfig, GatewayConfig, GatewayDnsConfig, PortForward, Proto};
 pub use node::{
     BloomConfig, BuffersConfig, CacheConfig, ControlConfig, DiscoveryConfig, LimitsConfig,
@@ -378,7 +378,7 @@ pub struct Config {
     pub peers: Vec<PeerConfig>,
 
     /// Gateway configuration (`gateway`).
-    #[cfg(feature = "gateway")]
+    #[cfg(target_os = "linux")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gateway: Option<GatewayConfig>,
 }
@@ -500,7 +500,7 @@ impl Config {
             self.peers = other.peers;
         }
         // Merge gateway section — higher-priority config replaces entirely
-        #[cfg(feature = "gateway")]
+        #[cfg(target_os = "linux")]
         if other.gateway.is_some() {
             self.gateway = other.gateway;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub mod bloom;
 pub mod cache;
 pub mod config;
 pub mod control;
-#[cfg(feature = "gateway")]
+#[cfg(target_os = "linux")]
 pub mod gateway;
 pub mod identity;
 pub mod mmp;

--- a/src/node/lifecycle.rs
+++ b/src/node/lifecycle.rs
@@ -125,7 +125,7 @@ impl Node {
                     }
                 }
             } else if addr.transport == "ble" {
-                #[cfg(target_os = "linux")]
+                #[cfg(bluer_available)]
                 {
                     match self.resolve_ble_addr(&addr.addr) {
                         Ok(result) => result,
@@ -140,11 +140,11 @@ impl Node {
                         }
                     }
                 }
-                #[cfg(not(target_os = "linux"))]
+                #[cfg(not(bluer_available))]
                 {
                     debug!(
                         transport = %addr.transport,
-                        "BLE transport not available on this platform"
+                        "BLE transport not available on this build"
                     );
                     continue;
                 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -800,7 +800,7 @@ impl Node {
         }
 
         // Create BLE transport instances
-        #[cfg(target_os = "linux")]
+        #[cfg(bluer_available)]
         {
             let ble_instances: Vec<_> = self
                 .config
@@ -810,7 +810,7 @@ impl Node {
                 .map(|(name, config)| (name.map(|s| s.to_string()), config.clone()))
                 .collect();
 
-            #[cfg(all(feature = "ble", not(test)))]
+            #[cfg(all(bluer_available, not(test)))]
             for (name, ble_config) in ble_instances {
                 let transport_id = self.allocate_transport_id();
                 let adapter = ble_config.adapter().to_string();
@@ -833,12 +833,10 @@ impl Node {
                 }
             }
 
-            #[cfg(any(not(feature = "ble"), test))]
+            #[cfg(any(not(bluer_available), test))]
             if !ble_instances.is_empty() {
                 #[cfg(not(test))]
-                tracing::warn!(
-                    "BLE transport configured but 'ble' feature not enabled at compile time"
-                );
+                tracing::warn!("BLE transport configured but this build lacks BlueZ support");
             }
         }
 
@@ -908,7 +906,7 @@ impl Node {
     /// Resolve a BLE address string (`"adapter/AA:BB:CC:DD:EE:FF"`) to a
     /// (TransportId, TransportAddr) pair by finding the BLE transport
     /// instance matching the adapter name.
-    #[cfg(target_os = "linux")]
+    #[cfg(bluer_available)]
     fn resolve_ble_addr(&self, addr_str: &str) -> Result<(TransportId, TransportAddr), NodeError> {
         let ta = TransportAddr::from_string(addr_str);
         let adapter = crate::transport::ble::addr::adapter_from_addr(&ta).ok_or_else(|| {

--- a/src/transport/ble/addr.rs
+++ b/src/transport/ble/addr.rs
@@ -55,10 +55,10 @@ impl BleAddr {
 }
 
 // ============================================================================
-// bluer type conversions (behind ble feature)
+// bluer type conversions (glibc-linux only; see build.rs bluer_available)
 // ============================================================================
 
-#[cfg(feature = "ble")]
+#[cfg(bluer_available)]
 impl BleAddr {
     /// Construct from a bluer `Address` and adapter name.
     pub fn from_bluer(addr: bluer::Address, adapter: &str) -> Self {

--- a/src/transport/ble/io.rs
+++ b/src/transport/ble/io.rs
@@ -1,7 +1,7 @@
 //! BLE I/O abstraction layer.
 //!
 //! Defines the `BleIo` trait that separates transport logic from the
-//! BlueZ/bluer stack. `BluerIo` (behind `cfg(feature = "ble")`) provides
+//! BlueZ/bluer stack. `BluerIo` (behind `cfg(bluer_available)`) provides
 //! the real implementation; `MockBleIo` provides an in-memory test double.
 
 use crate::transport::TransportError;
@@ -109,7 +109,7 @@ pub trait BleIo: Send + Sync + 'static {
 // BluerIo — Production BLE I/O via BlueZ D-Bus
 // ============================================================================
 
-#[cfg(feature = "ble")]
+#[cfg(bluer_available)]
 mod bluer_impl {
     use super::*;
     use crate::transport::TransportError;
@@ -486,7 +486,7 @@ mod bluer_impl {
     }
 }
 
-#[cfg(feature = "ble")]
+#[cfg(bluer_available)]
 pub use bluer_impl::{BluerAcceptor, BluerIo, BluerScanner, BluerStream, FIPS_SERVICE_UUID};
 
 // ============================================================================

--- a/src/transport/ble/mod.rs
+++ b/src/transport/ble/mod.rs
@@ -9,7 +9,7 @@
 //!
 //! Transport logic (pool, discovery, lifecycle) is separated from the
 //! BlueZ/bluer stack via the `BleIo` trait. `BluerIo` provides the real
-//! implementation (behind `cfg(feature = "ble")`); `MockBleIo` provides
+//! implementation (behind `cfg(bluer_available)`); `MockBleIo` provides
 //! an in-memory test double for CI without hardware.
 //!
 //! ## Connection Pool
@@ -50,12 +50,12 @@ pub const DEFAULT_PSM: u16 = 0x0085;
 
 /// Concrete BLE transport type for use in TransportHandle.
 ///
-/// Production builds with the `ble` feature use `BluerIo` (real BlueZ stack).
-/// Test builds and builds without `ble` use `MockBleIo`.
-#[cfg(all(feature = "ble", not(test)))]
+/// Production builds on glibc-linux use `BluerIo` (real BlueZ stack).
+/// Test builds, musl-linux, and non-Linux platforms use `MockBleIo`.
+#[cfg(all(bluer_available, not(test)))]
 pub type DefaultBleTransport = BleTransport<io::BluerIo>;
 
-#[cfg(any(not(feature = "ble"), test))]
+#[cfg(any(not(bluer_available), test))]
 pub type DefaultBleTransport = BleTransport<io::MockBleIo>;
 
 // ============================================================================

--- a/testing/ci-local.sh
+++ b/testing/ci-local.sh
@@ -149,8 +149,8 @@ record() {
 run_build() {
     stage "Stage 1: Build"
 
-    info "cargo build --release --features gateway"
-    if cargo build --release --features gateway 2>&1; then
+    info "cargo build --release"
+    if cargo build --release 2>&1; then
         record "build" 0
     else
         record "build" 1
@@ -165,8 +165,8 @@ run_build() {
         return 1
     fi
 
-    info "cargo clippy --all --features gateway -- -D warnings"
-    if cargo clippy --all --features gateway -- -D warnings 2>&1; then
+    info "cargo clippy --all -- -D warnings"
+    if cargo clippy --all -- -D warnings 2>&1; then
         record "clippy" 0
     else
         record "clippy" 1
@@ -181,7 +181,7 @@ run_tests() {
 
     local cmd
     if command -v cargo-nextest &>/dev/null; then
-        cmd="cargo nextest run --all --features gateway"
+        cmd="cargo nextest run --all"
         info "$cmd"
         if $cmd 2>&1; then
             record "unit-tests" 0
@@ -189,7 +189,7 @@ run_tests() {
             record "unit-tests" 1
         fi
     else
-        cmd="cargo test --all --features gateway"
+        cmd="cargo test --all"
         info "$cmd (nextest not found, using cargo test)"
         if $cmd 2>&1; then
             record "unit-tests" 0


### PR DESCRIPTION
## Summary

- Drop the `tui`, `ble`, and `gateway` cargo features. They were either redundant with platform cfg gates (ble, gateway are Linux-only deps) or no longer worth the surface area (ratatui binary-size concern doesn't hold in 2026). Plain `cargo build` now produces every subsystem appropriate for the target with no feature flags.
- Fix the long-standing cross-platform trap: `default = ["tui", "ble"]` pulled `bluer` (Linux-only) and broke `cargo build` on macOS and Windows. Every non-Linux packager needed `--no-default-features`.
- Cargo.toml, source cfg gates, packaging scripts, and CI workflows all simplified. Strip `--features` and `--no-default-features` flags across the matrix; defaults now match each platform's capabilities.

## Details

**Cargo.toml:**
- `[features]` collapses to `default = []`. `tui`, `ble`, `gateway` removed.
- `ratatui` promoted to non-optional top-level dep.
- `bluer` promoted to non-optional inside `[target.'cfg(target_os = "linux")'.dependencies]`.
- `rustables` moved from top-level optional into the Linux target block, non-optional.
- `required-features` dropped from both `fipstop` and `fips-gateway` `[[bin]]` entries.

**Source:**
- Every `#[cfg(feature = "ble")]` and `#[cfg(feature = "gateway")]` replaced with `#[cfg(target_os = "linux")]`. Files: `src/lib.rs`, `src/config/mod.rs`, `src/transport/ble/{mod,io,addr}.rs`, `src/node/mod.rs`.
- `src/bin/fips-gateway.rs`: Linux-only `main()` (unchanged behavior) plus a non-Linux stub that prints a diagnostic and exits 1. Binary builds on all platforms; non-Linux packaging scripts already don't ship it, so the stub sits unused in `target/release/`.

**Packaging scripts:** `--features` / `--no-default-features` flags stripped from Debian, systemd tarball, macOS .pkg, Windows .zip, OpenWrt .ipk, and AUR stable PKGBUILD. AUR `fips-git` now aligns with stable automatically.

**CI workflows:** Same strip across `ci.yml`, `package-{linux,macos,windows}.yml`, and `testing/ci-local.sh`.

## Related context

- Matches operator intent: one product (daemon + fipsctl + fipstop), with `fips-gateway` as a companion daemon. `cargo build` should produce everything the platform supports.
- `nostr-discovery` feature is untouched here because it doesn't exist on master — that work follows on the `nostr-discovery` branch (PR #53) as a rebase + Cargo.toml reshape after this lands. A cross-platform probe (`nostr-xplat-probe`) separately confirmed `nostr-sdk` 0.44 compiles and passes tests on macOS and Windows, so Phase 3 can use a cross-platform default.

## Test plan

- [x] `cargo build --release` (no flags) on Linux produces `fips`, `fipsctl`, `fipstop`, `fips-gateway`
- [x] CI all green: Linux/macOS/Windows builds, unit tests on all three, 15 integration suites (static-mesh, static-chain, acl-allowlist, rekey, sidecar, 10 chaos scenarios)
- [x] `grep -rn 'cfg(feature = "ble\|cfg(feature = "gateway\|cfg(feature = "tui' src/` returns no matches
- [ ] `cargo build --release` (no flags) on macOS produces stub `fips-gateway` — *verified in CI*
- [ ] `cargo build --release` (no flags) on Windows produces stub `fips-gateway.exe` — *verified in CI*
- [ ] Post-merge: confirm `dpkg -c fips_*_amd64.deb` still lists `/usr/bin/fips-gateway`