### PR TITLE
chore: replace real IPs in docs and configs with placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -535,9 +535,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   directly is impossible (1:1 NAT)
 - New `external_addr` field on `transports.udp.*` and
   `transports.tcp.*` for explicit advertise-as override. Accepts
-  either a bare IP (`"54.183.70.180"` — the configured `bind_addr`
+  either a bare IP (`"198.51.100.1"` — the configured `bind_addr`
   port is appended) or a full `host:port`
-  (`"54.183.70.180:8443"`). Takes precedence over both the bound
+  (`"198.51.100.1:8443"`). Takes precedence over both the bound
   address and any STUN-derived autodiscovery. Required for TCP
   on cloud-NAT setups (AWS EIP, GCP/Azure external IPs) where
   binding to the public IP directly fails with `EADDRNOTAVAIL`

--- a/docs/tutorials/resolve-peers-via-nostr.md
+++ b/docs/tutorials/resolve-peers-via-nostr.md
@@ -96,7 +96,7 @@ You should currently have:
   ```
 
   Expect `test-us01` listed with `connectivity` active and a
-  `transport_addr` of roughly `217.77.8.91:2121`.
+  `transport_addr` of roughly `test-us01.fips.network:2121`.
 
 If either of those isn't true, finish the previous two
 tutorials first; the Nostr discovery layer is built on top of
@@ -189,7 +189,7 @@ sudo fipsctl show peers
 
 `test-us01` should appear with `connectivity` active and a
 `transport_addr` reflecting the address that was resolved from
-the advert — `217.77.8.91:2121` at time of writing. That field
+the advert — `test-us01.fips.network:2121` at time of writing. That field
 is the strong signal: nothing in your config gave the daemon
 that IP, yet there it is.
 

--- a/examples/sidecar-nostr-relay/.env
+++ b/examples/sidecar-nostr-relay/.env
@@ -7,6 +7,6 @@ FIPS_NSEC=
 
 # Peer configuration (leave empty for standalone operation)
 FIPS_PEER_NPUB=npub1qmc3cvfz0yu2hx96nq3gp55zdan2qclealn7xshgr448d3nh6lks7zel98
-FIPS_PEER_ADDR=217.77.8.91:2121
+FIPS_PEER_ADDR=test-us01.fips.network:2121
 FIPS_PEER_ALIAS=vps
 FIPS_PEER_TRANSPORT=udp

--- a/examples/wireguard-sidecar-macos/fips.yaml
+++ b/examples/wireguard-sidecar-macos/fips.yaml
@@ -32,5 +32,5 @@ peers:
     alias: "fips-test-node"
     addresses:
       - transport: udp
-        addr: "217.77.8.91:2121"
+        addr: "test-us01.fips.network:2121"
     connect_policy: auto_connect

--- a/packaging/common/fips.yaml
+++ b/packaging/common/fips.yaml
@@ -116,7 +116,7 @@ peers: []
   #   via_nostr: true
   #   addresses:
   #     - transport: udp
-  #       addr: "217.77.8.91:2121"  # IP or hostname (e.g., "peer.example.com:2121")
+  #       addr: "test-us01.fips.network:2121"  # IP or hostname (e.g., "peer.example.com:2121")
   #     - transport: udp
   #       addr: "nat"  # Use node.discovery.nostr for Nostr/STUN hole punching
   #   connect_policy: auto_connect

--- a/packaging/openwrt-ipk/files/etc/fips/fips.yaml
+++ b/packaging/openwrt-ipk/files/etc/fips/fips.yaml
@@ -119,7 +119,7 @@ peers: []
   #   via_nostr: true
   #   addresses:
   #     - transport: udp
-  #       addr: "217.77.8.91:2121"  # IP or hostname (e.g., "peer.example.com:2121")
+  #       addr: "test-us01.fips.network:2121"  # IP or hostname (e.g., "peer.example.com:2121")
   #     - transport: udp
   #       addr: "nat"  # Use node.discovery.nostr for Nostr/STUN hole punching
   #   connect_policy: auto_connect

--- a/packaging/systemd/README.install.md
+++ b/packaging/systemd/README.install.md
@@ -109,7 +109,7 @@ peers:
     alias: "gateway"
     addresses:
       - transport: udp
-        addr: "217.77.8.91:2121"  # IP or hostname (e.g., "peer.example.com:2121")
+        addr: "test-us01.fips.network:2121"  # IP or hostname (e.g., "peer.example.com:2121")
     connect_policy: auto_connect
 ```
 

--- a/src/config/transport.rs
+++ b/src/config/transport.rs
@@ -11,9 +11,9 @@ use serde::{Deserialize, Serialize};
 /// Parse an `external_addr` config string against a known bind port,
 /// producing the absolute `SocketAddr` to advertise on Nostr.
 ///
-/// Accepts either a bare IP (`"54.183.70.180"` or `"[::1]"`) — in which
+/// Accepts either a bare IP (`"198.51.100.1"` or `"[::1]"`) — in which
 /// case the bind port is appended — or a full `host:port` form
-/// (`"54.183.70.180:443"` or `"[::1]:443"`). Returns `None` on any parse
+/// (`"198.51.100.1:443"` or `"[::1]:443"`). Returns `None` on any parse
 /// error. IPv6 must use bracket notation when supplying a port.
 fn parse_external_advert_addr(raw: &str, bind_port: u16) -> Option<SocketAddr> {
     if let Ok(sa) = raw.parse::<SocketAddr>() {
@@ -79,8 +79,8 @@ pub struct UdpConfig {
     /// Optional explicit public address to advertise when `public: true`
     /// is set. Takes precedence over both the bound address and any
     /// STUN-derived autodiscovery. Accepts either a bare IP
-    /// (`"54.183.70.180"` — the configured `bind_addr` port is appended)
-    /// or a full `host:port` (`"54.183.70.180:443"`). Useful when the
+    /// (`"198.51.100.1"` — the configured `bind_addr` port is appended)
+    /// or a full `host:port` (`"198.51.100.1:443"`). Useful when the
     /// public IP isn't on a local interface (e.g. AWS EIP / cloud 1:1
     /// NAT) and the operator wants to skip STUN autodiscovery for a
     /// deterministic value.
@@ -414,7 +414,7 @@ pub struct TcpConfig {
     /// Optional explicit public address to advertise. Required when
     /// `bind_addr` is wildcard (e.g. `"0.0.0.0:443"`) and
     /// `advertise_on_nostr: true`, since TCP has no STUN equivalent
-    /// for autodiscovery. Accepts either a bare IP (`"54.183.70.180"`
+    /// for autodiscovery. Accepts either a bare IP (`"198.51.100.1"`
     /// — the configured `bind_addr` port is appended) or a full
     /// `host:port`. Common pattern on AWS EIP / cloud 1:1 NAT setups
     /// where the public IP isn't bindable on the host.
@@ -875,14 +875,14 @@ mod tests {
 
     #[test]
     fn parse_external_addr_accepts_bare_ipv4_with_appended_bind_port() {
-        let sa = parse_external_advert_addr("54.183.70.180", 2121).unwrap();
-        assert_eq!(sa.to_string(), "54.183.70.180:2121");
+        let sa = parse_external_advert_addr("198.51.100.1", 2121).unwrap();
+        assert_eq!(sa.to_string(), "198.51.100.1:2121");
     }
 
     #[test]
     fn parse_external_addr_accepts_full_ipv4_socket_addr() {
-        let sa = parse_external_advert_addr("54.183.70.180:443", 2121).unwrap();
-        assert_eq!(sa.to_string(), "54.183.70.180:443");
+        let sa = parse_external_advert_addr("198.51.100.1:443", 2121).unwrap();
+        assert_eq!(sa.to_string(), "198.51.100.1:443");
         // Explicit port wins over the bind port we passed in.
     }
 
@@ -907,23 +907,23 @@ mod tests {
     #[test]
     fn udp_external_advert_addr_combines_with_bind_port_default() {
         let cfg = UdpConfig {
-            external_addr: Some("54.183.70.180".to_string()),
+            external_addr: Some("198.51.100.1".to_string()),
             ..UdpConfig::default()
         };
         // bind_addr unset, so default DEFAULT_UDP_BIND_ADDR (0.0.0.0:2121) applies.
         let sa = cfg.external_advert_addr().unwrap();
-        assert_eq!(sa.to_string(), "54.183.70.180:2121");
+        assert_eq!(sa.to_string(), "198.51.100.1:2121");
     }
 
     #[test]
     fn udp_external_advert_addr_with_explicit_full_socket_addr_overrides_bind_port() {
         let cfg = UdpConfig {
             bind_addr: Some("0.0.0.0:2121".to_string()),
-            external_addr: Some("54.183.70.180:9999".to_string()),
+            external_addr: Some("198.51.100.1:9999".to_string()),
             ..UdpConfig::default()
         };
         let sa = cfg.external_advert_addr().unwrap();
-        assert_eq!(sa.to_string(), "54.183.70.180:9999");
+        assert_eq!(sa.to_string(), "198.51.100.1:9999");
     }
 
     #[test]
@@ -935,7 +935,7 @@ mod tests {
     #[test]
     fn tcp_external_advert_addr_requires_bind_port() {
         let cfg = TcpConfig {
-            external_addr: Some("54.183.70.180".to_string()),
+            external_addr: Some("198.51.100.1".to_string()),
             ..TcpConfig::default()
         };
         // bind_addr unset → no port to combine with → None.
@@ -943,22 +943,22 @@ mod tests {
 
         let cfg = TcpConfig {
             bind_addr: Some("0.0.0.0:443".to_string()),
-            external_addr: Some("54.183.70.180".to_string()),
+            external_addr: Some("198.51.100.1".to_string()),
             ..TcpConfig::default()
         };
         let sa = cfg.external_advert_addr().unwrap();
-        assert_eq!(sa.to_string(), "54.183.70.180:443");
+        assert_eq!(sa.to_string(), "198.51.100.1:443");
     }
 
     #[test]
     fn tcp_external_advert_addr_with_full_socket_addr_independent_of_bind() {
         let cfg = TcpConfig {
             bind_addr: Some("0.0.0.0:443".to_string()),
-            external_addr: Some("54.183.70.180:8443".to_string()),
+            external_addr: Some("198.51.100.1:8443".to_string()),
             ..TcpConfig::default()
         };
         let sa = cfg.external_advert_addr().unwrap();
-        assert_eq!(sa.to_string(), "54.183.70.180:8443");
+        assert_eq!(sa.to_string(), "198.51.100.1:8443");
     }
 
     #[test]

--- a/testing/sidecar/.env
+++ b/testing/sidecar/.env
@@ -8,6 +8,6 @@ FIPS_NSEC=e752b92aed3ac1595807f5d0eb5125589fbec0a2cfd3a2948d87ea076557deeb
 
 # Peer configuration (leave empty for standalone operation)
 FIPS_PEER_NPUB=npub1qmc3cvfz0yu2hx96nq3gp55zdan2qclealn7xshgr448d3nh6lks7zel98
-FIPS_PEER_ADDR=217.77.8.91:2121
+FIPS_PEER_ADDR=test-us01.fips.network:2121
 FIPS_PEER_ALIAS=vps
 FIPS_PEER_TRANSPORT=udp

--- a/testing/static/configs/topologies/mesh-public.yaml
+++ b/testing/static/configs/topologies/mesh-public.yaml
@@ -38,7 +38,7 @@ nodes:
   # External/public node (not a Docker container)
   pub:
     npub: "npub1qmc3cvfz0yu2hx96nq3gp55zdan2qclealn7xshgr448d3nh6lks7zel98"
-    external_ip: "217.77.8.91"
+    external_ip: "test-us01.fips.network"
     peers: [a, b, c]
 
 # Spanning Tree Structure (rooted at node A):

--- a/testing/tor/socks5-outbound/configs/node-a.yaml.tmpl
+++ b/testing/tor/socks5-outbound/configs/node-a.yaml.tmpl
@@ -1,6 +1,6 @@
 # FIPS Tor test node A — socks5-outbound
 #
-# Connects outbound to test-us01 (217.77.8.91:443) via Tor SOCKS5 proxy.
+# Connects outbound to test-us01 (test-us01.fips.network:443) via Tor SOCKS5 proxy.
 # Identity generated per-run to avoid mesh clashes with parallel tests.
 
 node:
@@ -24,5 +24,5 @@ peers:
     alias: "test-us01"
     addresses:
       - transport: tor
-        addr: "217.77.8.91:443"
+        addr: "test-us01.fips.network:443"
     connect_policy: auto_connect

--- a/testing/tor/socks5-outbound/configs/node-b.yaml.tmpl
+++ b/testing/tor/socks5-outbound/configs/node-b.yaml.tmpl
@@ -1,6 +1,6 @@
 # FIPS Tor test node B — socks5-outbound
 #
-# Connects outbound to test-us01 (217.77.8.91:443) via Tor SOCKS5 proxy.
+# Connects outbound to test-us01 (test-us01.fips.network:443) via Tor SOCKS5 proxy.
 # Identity generated per-run to avoid mesh clashes with parallel tests.
 
 node:
@@ -24,5 +24,5 @@ peers:
     alias: "test-us01"
     addresses:
       - transport: tor
-        addr: "217.77.8.91:443"
+        addr: "test-us01.fips.network:443"
     connect_policy: auto_connect

--- a/testing/tor/socks5-outbound/docker-compose.yml
+++ b/testing/tor/socks5-outbound/docker-compose.yml
@@ -1,7 +1,7 @@
 # Tor transport integration test — socks5-outbound
 #
 # Topology:
-#   [fips-a] --tor/socks5--> test-us01 (217.77.8.91:443) <--tor/socks5-- [fips-b]
+#   [fips-a] --tor/socks5--> test-us01 (test-us01.fips.network:443) <--tor/socks5-- [fips-b]
 #
 # Both FIPS nodes connect outbound through a local Tor daemon's SOCKS5
 # proxy to test-us01's TCP listener. test-us01 routes between them.

--- a/testing/tor/socks5-outbound/scripts/tor-test.sh
+++ b/testing/tor/socks5-outbound/scripts/tor-test.sh
@@ -5,7 +5,7 @@
 #   fips-a --tor/socks5--> test-us01 <--tor/socks5-- fips-b
 #
 # Both local FIPS nodes connect outbound through a local Tor daemon
-# to test-us01's TCP listener (217.77.8.91:443). Once both are peered
+# to test-us01's TCP listener (test-us01.fips.network:443). Once both are peered
 # with test-us01, traffic between fips-a and fips-b is routed through it.
 #
 # Each run generates ephemeral identities to avoid mesh clashes when


### PR DESCRIPTION
Operator-facing IPs in user-visible configs/docs (examples, tutorials, packaging, sidecar templates) are now the resolvable hostnames of the public test fleet (test-us01.fips.network, etc.) so they keep working without baking specific addresses into examples.

Doc-comment and test fixtures in src/config/transport.rs use RFC 5737 TEST-NET-2 (198.51.100.1) so they cannot accidentally point at a real host.