### PR TITLE
ci: fix AUR publish for fips, add fips-git publish workflow

### DIFF
--- a/.github/workflows/aur-publish-git.yml
+++ b/.github/workflows/aur-publish-git.yml
@@ -10,7 +10,6 @@ on:
       - 'packaging/aur/fips.sysusers'
       - 'packaging/aur/fips.tmpfiles'
       - 'packaging/aur/fips.install'
-      - '.github/workflows/aur-publish-git.yml'
 
 jobs:
   aur-publish-fips-git:
@@ -19,6 +18,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Patch PKGBUILD-git b2sums for local assets
+        run: |
+          set -euo pipefail
+          SYSUSERS_SUM=$(b2sum packaging/aur/fips.sysusers | awk '{print $1}')
+          TMPFILES_SUM=$(b2sum packaging/aur/fips.tmpfiles | awk '{print $1}')
+          if [ -z "$SYSUSERS_SUM" ] || [ -z "$TMPFILES_SUM" ]; then
+            echo "Failed to compute asset b2sums"; exit 1
+          fi
+          awk -v s1="$SYSUSERS_SUM" -v s2="$TMPFILES_SUM" '
+            /^b2sums=\(/ { in_block=1; count=0 }
+            in_block {
+              count++
+              if (count == 2) sub(/[a-f0-9]{128}/, s1)
+              if (count == 3) sub(/[a-f0-9]{128}/, s2)
+              if ($0 ~ /\)/) in_block=0
+            }
+            { print }
+          ' packaging/aur/PKGBUILD-git > packaging/aur/PKGBUILD-git.new
+          mv packaging/aur/PKGBUILD-git.new packaging/aur/PKGBUILD-git
+          echo "Patched PKGBUILD-git b2sums:"
+          awk '/^b2sums=\(/,/\)$/' packaging/aur/PKGBUILD-git
 
       - name: Publish to AUR
         uses: KSXGitHub/github-actions-deploy-aur@v4.1.2

--- a/.github/workflows/aur-publish-git.yml
+++ b/.github/workflows/aur-publish-git.yml
@@ -1,0 +1,36 @@
+name: AUR Publish (fips-git)
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - 'packaging/aur/PKGBUILD-git'
+      - 'packaging/aur/fips.sysusers'
+      - 'packaging/aur/fips.tmpfiles'
+      - 'packaging/aur/fips.install'
+      - '.github/workflows/aur-publish-git.yml'
+
+jobs:
+  aur-publish-fips-git:
+    name: Publish fips-git to AUR
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.2
+        with:
+          pkgname: fips-git
+          pkgbuild: packaging/aur/PKGBUILD-git
+          updpkgsums: false
+          assets: |
+            packaging/aur/fips.sysusers
+            packaging/aur/fips.tmpfiles
+            packaging/aur/fips.install
+          commit_username: ${{ github.repository_owner }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "Update PKGBUILD-git (${{ github.sha }})"

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           ref: ${{ steps.tag.outputs.tag }}
 
-      - name: Patch PKGBUILD with pkgver and source b2sum
+      - name: Patch PKGBUILD with pkgver and b2sums
         env:
           TAG: ${{ steps.tag.outputs.tag }}
           VERSION: ${{ steps.tag.outputs.version }}
@@ -52,14 +52,29 @@ jobs:
           set -euo pipefail
           URL="https://github.com/${GITHUB_REPOSITORY}/archive/${TAG}.tar.gz"
           echo "Fetching $URL"
-          SUM=$(curl -fsSL --retry 3 "$URL" | b2sum | awk '{print $1}')
-          if [ -z "$SUM" ]; then
-            echo "Failed to compute b2sum of source tarball"; exit 1
-          fi
+          SOURCE_SUM=$(curl -fsSL --retry 3 "$URL" | b2sum | awk '{print $1}')
+          SYSUSERS_SUM=$(b2sum packaging/aur/fips.sysusers | awk '{print $1}')
+          TMPFILES_SUM=$(b2sum packaging/aur/fips.tmpfiles | awk '{print $1}')
+          for v in SOURCE_SUM SYSUSERS_SUM TMPFILES_SUM; do
+            eval val=\$$v
+            if [ -z "$val" ]; then echo "$v is empty"; exit 1; fi
+          done
           sed -i "s/^pkgver=.*/pkgver=${VERSION}/" packaging/aur/PKGBUILD
-          sed -i "s|^b2sums=('SKIP'.*|b2sums=('${SUM}'|" packaging/aur/PKGBUILD
+          sed -i "s|^b2sums=('SKIP'.*|b2sums=('${SOURCE_SUM}'|" packaging/aur/PKGBUILD
+          awk -v s1="$SYSUSERS_SUM" -v s2="$TMPFILES_SUM" '
+            /^b2sums=\(/ { in_block=1; count=0 }
+            in_block {
+              count++
+              if (count == 2) sub(/[a-f0-9]{128}/, s1)
+              if (count == 3) sub(/[a-f0-9]{128}/, s2)
+              if ($0 ~ /\)/) in_block=0
+            }
+            { print }
+          ' packaging/aur/PKGBUILD > packaging/aur/PKGBUILD.new
+          mv packaging/aur/PKGBUILD.new packaging/aur/PKGBUILD
           echo "Patched PKGBUILD:"
-          grep -E "^(pkgver|b2sums)=" packaging/aur/PKGBUILD
+          grep -E "^pkgver=" packaging/aur/PKGBUILD
+          awk '/^b2sums=\(/,/\)$/' packaging/aur/PKGBUILD
 
       - name: Publish to AUR
         uses: KSXGitHub/github-actions-deploy-aur@v4.1.2

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -2,6 +2,11 @@ name: AUR Publish
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g. v0.3.0). Defaults to the tag the workflow was dispatched from.'
+        required: false
+        default: ''
   push:
     tags:
       - 'v*'
@@ -10,23 +15,58 @@ jobs:
   aur-publish-fips:
     name: Publish fips to AUR
     runs-on: ubuntu-latest
-    continue-on-error: true
-    if: "!contains(github.ref_name, '-')"
+    if: github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-')
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Update pkgver in PKGBUILD
+      - name: Resolve release tag
+        id: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          set -euo pipefail
+          TAG="${INPUT_TAG:-$GITHUB_REF_NAME}"
+          case "$TAG" in
+            v*) ;;
+            *) echo "Tag '$TAG' does not look like a release tag (vX.Y.Z)"; exit 1 ;;
+          esac
+          case "$TAG" in
+            *-*)
+              if [ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]; then
+                echo "Pre-release tag '$TAG' — skipping AUR publish"
+                exit 1
+              fi
+              ;;
+          esac
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - name: Patch PKGBUILD with pkgver and source b2sum
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          URL="https://github.com/${GITHUB_REPOSITORY}/archive/${TAG}.tar.gz"
+          echo "Fetching $URL"
+          SUM=$(curl -fsSL --retry 3 "$URL" | b2sum | awk '{print $1}')
+          if [ -z "$SUM" ]; then
+            echo "Failed to compute b2sum of source tarball"; exit 1
+          fi
           sed -i "s/^pkgver=.*/pkgver=${VERSION}/" packaging/aur/PKGBUILD
+          sed -i "s|^b2sums=('SKIP'.*|b2sums=('${SUM}'|" packaging/aur/PKGBUILD
+          echo "Patched PKGBUILD:"
+          grep -E "^(pkgver|b2sums)=" packaging/aur/PKGBUILD
 
       - name: Publish to AUR
         uses: KSXGitHub/github-actions-deploy-aur@v4.1.2
         with:
           pkgname: fips
           pkgbuild: packaging/aur/PKGBUILD
-          updpkgsums: true
+          updpkgsums: false
           assets: |
             packaging/aur/fips.sysusers
             packaging/aur/fips.tmpfiles
@@ -34,4 +74,4 @@ jobs:
           commit_username: ${{ github.repository_owner }}
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-          commit_message: "Update to ${{ github.ref_name }}"
+          commit_message: "Update to ${{ steps.tag.outputs.tag }}"


### PR DESCRIPTION
## Summary

Two AUR-related workflow changes:

### `aur-publish.yml` (stable `fips`)
- Fixes AUR publish failure where the source tarball was committed into the AUR repo and rejected by AUR's 488 KiB max-blob hook. Root cause: `updpkgsums: true` caused `makepkg` to download `fips-<ver>.tar.gz` into the AUR working tree, where it was then staged by the deploy action.
- Pre-computes the source b2sum in the workflow (fetch + `b2sum`), patches `pkgver` and the `b2sums=('SKIP'…)` placeholder in-place, and publishes with `updpkgsums: false` so the AUR clone stays metadata-only.
- Adds a `workflow_dispatch` `tag` input so historical tags can be re-published manually (used successfully to publish [v0.3.0](https://aur.archlinux.org/packages/fips) → `0.3.0-1`).
- Drops `continue-on-error: true` so future regressions surface in CI.

### `aur-publish-git.yml` (new — VCS `fips-git`)
- Adds a workflow that publishes the `fips-git` VCS PKGBUILD to AUR. Triggered only on master pushes that touch `PKGBUILD-git` / its companion files, plus `workflow_dispatch`. Not tied to release tags — pkgver is computed at build time by the PKGBUILD's `pkgver()` function.
- Reuses the same `AUR_EMAIL` / `AUR_SSH_PRIVATE_KEY` secrets; `pkgname: fips-git` selects the right AUR repo.

## Test plan
- [x] Manually dispatched against `v0.3.0` from this branch — AUR now shows `fips 0.3.0-1`.
- [ ] After merge, manually dispatch `aur-publish-git.yml` to publish `fips-git` for the first time.
- [ ] Next real release tag push verifies the automatic path for stable `fips` end-to-end.