### PR TITLE
chore: quiet platform-specific warnings

### DIFF
--- a/src/control/firewall_state.rs
+++ b/src/control/firewall_state.rs
@@ -31,6 +31,8 @@
 //! and the ICMPv6-echo-request accept are not classified — they
 //! don't pertain to listening TCP/UDP ports the operator binds.
 
+#![cfg_attr(not(target_os = "linux"), allow(dead_code))]
+
 use serde_json::Value;
 
 use crate::control::listening::Proto;

--- a/src/transport/ethernet/socket_macos.rs
+++ b/src/transport/ethernet/socket_macos.rs
@@ -534,8 +534,8 @@ fn get_mac_addr(interface: &str) -> Result<[u8; 6], TransportError> {
                     // MAC address starts after the interface name in sdl_data
                     let data_ptr = sdl.sdl_data.as_ptr();
                     let mut mac = [0u8; 6];
-                    for i in 0..6 {
-                        mac[i] = unsafe { *data_ptr.add(nlen + i) } as u8;
+                    for (i, byte) in mac.iter_mut().enumerate() {
+                        *byte = unsafe { *data_ptr.add(nlen + i) } as u8;
                     }
                     return Ok(mac);
                 }
@@ -565,6 +565,7 @@ fn get_mac_addr(interface: &str) -> Result<[u8; 6], TransportError> {
 
 #[cfg(test)]
 #[cfg(target_os = "macos")]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
 

--- a/src/upper/tun.rs
+++ b/src/upper/tun.rs
@@ -389,6 +389,7 @@ fn utun_af_inet6_header() -> [u8; 4] {
 /// from the dup'd fd directly.
 #[cfg(target_os = "macos")]
 #[inline]
+#[allow(dead_code)]
 fn parse_utun_af_prefix(buf: &[u8]) -> Option<u32> {
     if buf.len() < 4 {
         return None;
@@ -565,6 +566,7 @@ impl Drop for ShutdownFd {
 /// avoiding the need to close the TUN fd externally (which would cause a
 /// double-close when `TunDevice` drops).
 #[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
 pub fn run_tun_reader(
     mut device: TunDevice,
     mtu: u16,


### PR DESCRIPTION
## What was happening

Running the regular test build on macOS emitted warnings from code that is intentionally platform-specific: the nftables firewall parser is Linux-only, the utun address-family helper is only used in macOS TUN paths, and one macOS Ethernet test module trips a clippy layout lint. These warnings made focused test runs noisy and encouraged bundling unrelated warning fixes into behavioral PRs.

## What changed

- Gate the firewall parser dead-code allowance to non-Linux targets, where the parser is compiled but not used.
- Mark the macOS utun helper and long TUN reader entry point with narrow allowances.
- Rewrite the small MAC-copy loop to satisfy clippy and mark the macOS Ethernet test module layout explicitly.

There is no runtime behavior change.

## Tests

- `cargo fmt --check`
- `cargo test test_node_start_does_not_wait_for_nostr_relay_startup -- --nocapture` (compilation-only on this branch; the filtered test lives in a follow-up branch)