### PR TITLE
Fix missing fips-dns-setup + fix package transition to fips

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -7,6 +7,10 @@ on:
         description: 'Release tag to publish (e.g. v0.3.0). Defaults to the tag the workflow was dispatched from.'
         required: false
         default: ''
+      pkgrel:
+        description: 'AUR pkgrel to publish. Use 2+ for packaging-only republishes of an existing tag.'
+        required: false
+        default: '1'
   push:
     tags:
       - 'v*'
@@ -22,12 +26,17 @@ jobs:
         id: tag
         env:
           INPUT_TAG: ${{ inputs.tag }}
+          INPUT_PKGREL: ${{ inputs.pkgrel }}
         run: |
           set -euo pipefail
           TAG="${INPUT_TAG:-$GITHUB_REF_NAME}"
+          PKGREL="${INPUT_PKGREL:-1}"
           case "$TAG" in
             v*) ;;
             *) echo "Tag '$TAG' does not look like a release tag (vX.Y.Z)"; exit 1 ;;
+          esac
+          case "$PKGREL" in
+            ''|*[!0-9]*|0) echo "pkgrel '$PKGREL' must be a positive integer"; exit 1 ;;
           esac
           case "$TAG" in
             *-*)
@@ -39,15 +48,17 @@ jobs:
           esac
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "pkgrel=${PKGREL}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v4
         with:
           ref: ${{ steps.tag.outputs.tag }}
 
-      - name: Patch PKGBUILD with pkgver and b2sums
+      - name: Patch PKGBUILD with pkgver, pkgrel, conflicts, and b2sums
         env:
           TAG: ${{ steps.tag.outputs.tag }}
           VERSION: ${{ steps.tag.outputs.version }}
+          PKGREL: ${{ steps.tag.outputs.pkgrel }}
         run: |
           set -euo pipefail
           URL="https://github.com/${GITHUB_REPOSITORY}/archive/${TAG}.tar.gz"
@@ -60,6 +71,9 @@ jobs:
             if [ -z "$val" ]; then echo "$v is empty"; exit 1; fi
           done
           sed -i "s/^pkgver=.*/pkgver=${VERSION}/" packaging/aur/PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=${PKGREL}/" packaging/aur/PKGBUILD
+          sed -i "s/^conflicts=.*/conflicts=('fips-git' 'fips-git-debug')/" packaging/aur/PKGBUILD
+          sed -i "s/^options=.*/options=('!lto' '!debug')/" packaging/aur/PKGBUILD
           sed -i "s|^b2sums=('SKIP'.*|b2sums=('${SOURCE_SUM}'|" packaging/aur/PKGBUILD
           awk -v s1="$SYSUSERS_SUM" -v s2="$TMPFILES_SUM" '
             /^b2sums=\(/ { in_block=1; count=0 }
@@ -73,7 +87,7 @@ jobs:
           ' packaging/aur/PKGBUILD > packaging/aur/PKGBUILD.new
           mv packaging/aur/PKGBUILD.new packaging/aur/PKGBUILD
           echo "Patched PKGBUILD:"
-          grep -E "^pkgver=" packaging/aur/PKGBUILD
+          grep -E "^(pkgver|pkgrel|conflicts|options)=" packaging/aur/PKGBUILD
           awk '/^b2sums=\(/,/\)$/' packaging/aur/PKGBUILD
 
       - name: Publish to AUR

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -9,7 +9,7 @@ arch=('x86_64')
 depends=('gcc-libs' 'glibc')
 makedepends=('cargo')
 optdepends=('systemd-resolved: .fips DNS resolution')
-conflicts=('fips-git')
+conflicts=('fips-git' 'fips-git-debug')
 backup=('etc/fips/fips.yaml' 'etc/fips/hosts' 'etc/fips/fips.nft')
 install=fips.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/jmcorgan/fips/archive/v$pkgver.tar.gz"
@@ -18,7 +18,7 @@ source=("$pkgname-$pkgver.tar.gz::https://github.com/jmcorgan/fips/archive/v$pkg
 b2sums=('SKIP'  # tarball hash computed by CI via updpkgsums on release
         '25a0552f3d67d12f48dfd40fe4776ad7c46afeeab76bd2674b48e234db3c145810a24569a8c1a7f4c186eb546f0fae2ebe1550080c0e91d8eb72ba9934c752a6'
         '844257cb8e09cd935d0d6345922d0f3ec777411daca20e24175b346a7b3cb95ebce12631a9466c4d94f1588ed8d62d92514ff24025ccfd0efb358e542b454b00')
-options=('!lto')
+options=('!lto' '!debug')
 
 prepare() {
     cd "$pkgname-$pkgver"
@@ -52,6 +52,10 @@ package() {
     install -Dm0644 packaging/debian/fips-dns.service "$pkgdir/usr/lib/systemd/system/fips-dns.service"
     install -Dm0644 packaging/debian/fips-gateway.service "$pkgdir/usr/lib/systemd/system/fips-gateway.service"
     install -Dm0644 packaging/debian/fips-firewall.service "$pkgdir/usr/lib/systemd/system/fips-firewall.service"
+
+    # DNS helper scripts referenced by fips-dns.service
+    install -Dm0755 packaging/common/fips-dns-setup "$pkgdir/usr/lib/fips/fips-dns-setup"
+    install -Dm0755 packaging/common/fips-dns-teardown "$pkgdir/usr/lib/fips/fips-dns-teardown"
 
     # Config files (from packaging/common/)
     install -Dm0600 packaging/common/fips.yaml "$pkgdir/etc/fips/fips.yaml"

--- a/packaging/aur/PKGBUILD-git
+++ b/packaging/aur/PKGBUILD-git
@@ -10,7 +10,7 @@ depends=('dbus' 'gcc-libs' 'glibc')
 makedepends=('cargo' 'git')
 optdepends=('systemd-resolved: .fips DNS resolution')
 provides=('fips')
-conflicts=('fips')
+conflicts=('fips' 'fips-debug')
 backup=('etc/fips/fips.yaml' 'etc/fips/hosts' 'etc/fips/fips.nft')
 install=fips.install
 source=("fips::git+https://github.com/jmcorgan/fips.git"
@@ -59,6 +59,10 @@ package() {
     install -Dm0644 packaging/debian/fips-dns.service "$pkgdir/usr/lib/systemd/system/fips-dns.service"
     install -Dm0644 packaging/debian/fips-gateway.service "$pkgdir/usr/lib/systemd/system/fips-gateway.service"
     install -Dm0644 packaging/debian/fips-firewall.service "$pkgdir/usr/lib/systemd/system/fips-firewall.service"
+
+    # DNS helper scripts referenced by fips-dns.service
+    install -Dm0755 packaging/common/fips-dns-setup "$pkgdir/usr/lib/fips/fips-dns-setup"
+    install -Dm0755 packaging/common/fips-dns-teardown "$pkgdir/usr/lib/fips/fips-dns-teardown"
 
     # Config files (from packaging/common/)
     install -Dm0600 packaging/common/fips.yaml "$pkgdir/etc/fips/fips.yaml"

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -31,6 +31,8 @@ package:
 - Binaries: `fips`, `fipsctl`, `fipstop`, `fips-gateway`
 - Systemd units: `fips.service`, `fips-dns.service`, `fips-gateway.service`,
   `fips-firewall.service`
+- DNS helpers: `/usr/lib/fips/fips-dns-setup`,
+  `/usr/lib/fips/fips-dns-teardown`
 - Config: `/etc/fips/fips.yaml`, `/etc/fips/hosts`, `/etc/fips/fips.nft`
 - sysusers/tmpfiles fragments for the `fips` group and `/run/fips/`
 
@@ -38,6 +40,11 @@ The `fips.nft` baseline is shipped as a conffile (listed in `backup=()`) so
 operator edits to the nftables ruleset survive package upgrades.
 `fips-firewall.service` is shipped disabled by default, matching the Debian
 package: operators opt in by enabling it explicitly.
+
+Both PKGBUILDs opt out of makepkg's automatic `*-debug` split packages. The
+package metadata still conflicts with stale peer debug package names
+(`fips-debug` / `fips-git-debug`) so switching between release and development
+variants removes old debug-file owners cleanly.
 
 ## Local Build and Validation
 
@@ -321,3 +328,8 @@ Push an update when a new version is tagged. The steps are:
 
 Phase 4 CI automation will handle this workflow automatically on new GitHub
 releases.
+
+For a packaging-only republish of an existing release tag, run the AUR Publish
+workflow manually with the existing tag and incremented `pkgrel` (for example,
+`tag=v0.3.0`, `pkgrel=2`). This keeps the upstream source tarball unchanged
+while forcing AUR helpers to rebuild with the corrected package metadata.


### PR DESCRIPTION
`PKGBUILD` now installs `fips-dns-setup` and `fips-dns-teardown` into `/usr/lib/fips/`,  matching `fips-dns.service`.

_Super ultra bonus fix:_

_Resolves a package-transition bug found in a previously untested path:_ systems with an older `fips-git-debug` split package installed could fail when switching from `fips-git` to `fips`. Release `PKGBUILD` disables debug split packages and declares a stale peer `debug` as a conflict, resulting in user being shown two safe conflict-removal prompts: 

```
...
:: fips-0.3.0-2 and fips-git-0.3.0.r0.g1617f6e-1 are in conflict. Remove fips-git? [y/N] y
:: fips-0.3.0-2 and fips-git-debug-0.1.0.r21.g9e63b42-1 are in conflict. Remove fips-git-debug? [y/N] y
...
```

Local validation script (  :pen: :robot: ) 

_from fips source root; this branch_

```bash
tmp=$(mktemp -d) && \
cp ./packaging/aur/{PKGBUILD,fips.install,fips.sysusers,fips.tmpfiles} "$tmp"/ && \
cd "$tmp" && \
version=0.3.0 && \
source_sum=$(curl -fsSL "https://github.com/jmcorgan/fips/archive/v${version}.tar.gz" | b2sum | awk '{print $1}') && \
sed -i "s/^pkgver=.*/pkgver=${version}/" PKGBUILD && \
sed -i "s/^pkgrel=.*/pkgrel=2/" PKGBUILD && \
sed -i "s|^b2sums=('SKIP'.*|b2sums=('${source_sum}'|" PKGBUILD && \
makepkg --printsrcinfo > .SRCINFO && \
makepkg -Csf && \
bsdtar -tf fips-${version}-2-*.pkg.tar.zst | grep -E 'usr/lib/fips/fips-dns-(setup|teardown)$|usr/lib/systemd/system/fips-dns.service$' && \
pacman -Qq fips-git fips-git-debug 2>/dev/null || true && \
sudo pacman -U ./fips-${version}-2-*.pkg.tar.zst
```

resolves #98  