### PR TITLE
packaging: macOS resolver must point at ::1, not 127.0.0.1

### DIFF
--- a/packaging/macos/build-pkg.sh
+++ b/packaging/macos/build-pkg.sh
@@ -121,9 +121,9 @@ cp "${PACKAGING_DIR}/common/hosts" "${STAGING_DIR}/usr/local/etc/fips/hosts.defa
 # LaunchDaemon plist
 cp "${SCRIPT_DIR}/com.fips.daemon.plist" "${STAGING_DIR}/Library/LaunchDaemons/"
 
-# DNS resolver
+# DNS resolver. Must match the daemon's dns.bind_addr (defaults to ::1).
 cat > "${STAGING_DIR}/etc/resolver/fips" <<EOF
-nameserver 127.0.0.1
+nameserver ::1
 port 5354
 EOF
 


### PR DESCRIPTION
## Summary
- `/etc/resolver/fips` has shipped `nameserver 127.0.0.1` on macOS since the resolver shim was introduced in [`e693f4f`](https://github.com/jmcorgan/fips/commit/e693f4f) (initial macOS packaging). That was fine at the time — the daemon defaulted `dns.bind_addr` to `"::"` (wildcard), so v4 loopback traffic landed on the same socket.
- [`bf77ece`](https://github.com/jmcorgan/fips/commit/bf77ece) (2026-04-29, "Fix DNS responder silent-drop on systemd-resolved deployments") tightened the daemon default to `"::1"` (IPv6 loopback only — does not accept v4-mapped traffic) to defuse a mesh-interface filter / `IPV6_PKTINFO` bug on Linux. The Linux side was updated in lockstep: `fips-dns-setup` rewrites all backends (dns-delegate, resolved global drop-in, resolvectl, dnsmasq, NM-dnsmasq) to `[::1]:5354`, and the gateway's `DEFAULT_DNS_UPSTREAM` moved to `[::1]:5354` with a clear inline comment.
- The macOS resolver shim in [packaging/macos/build-pkg.sh](packaging/macos/build-pkg.sh) was missed in that sweep. Result: every macOS install since 2026-04-29 silently fails to resolve `.fips` hostnames via `getaddrinfo` (ping6, curl, etc.) even though `dig @::1 -p 5354 …` works.
- The mismatch is easy to miss: mDNSResponder swallows the timeout, VPN clients with a NetworkExtension match-everything DNS policy mask it entirely, and the symptom usually looks like "discovery hasn't found the peer yet" rather than "the resolver shim is pointing nowhere".
- Switch the shim to `nameserver ::1` to match the daemon's default bind.

## Test plan
- [x] Reinstall the pkg on macOS, verify `cat /etc/resolver/fips` shows `nameserver ::1`.
- [x] `dig @::1 -p 5354 <npub>.fips AAAA` and `ping6 <npub>.fips` both succeed.