### PR TITLE
Add Nym mixnet transport

### DIFF
--- a/src/bin/fipstop/ui/transports.rs
+++ b/src/bin/fipstop/ui/transports.rs
@@ -478,6 +478,30 @@ fn draw_transport_detail(frame: &mut Frame, app: &App, area: Rect, t: &serde_jso
                     &helpers::nested_u64(t, "stats", "connect_refused"),
                 ));
             }
+            "nym" => {
+                lines.push(helpers::kv_line(
+                    "MTU Exceeded",
+                    &helpers::nested_u64(t, "stats", "mtu_exceeded"),
+                ));
+                lines.push(helpers::kv_line(
+                    "SOCKS5 Errors",
+                    &helpers::nested_u64(t, "stats", "socks5_errors"),
+                ));
+                lines.push(Line::from(""));
+                lines.push(helpers::section_header("Connections"));
+                lines.push(helpers::kv_line(
+                    "Established",
+                    &helpers::nested_u64(t, "stats", "connections_established"),
+                ));
+                lines.push(helpers::kv_line(
+                    "Timeouts",
+                    &helpers::nested_u64(t, "stats", "connect_timeouts"),
+                ));
+                lines.push(helpers::kv_line(
+                    "Refused",
+                    &helpers::nested_u64(t, "stats", "connect_refused"),
+                ));
+            }
             "ethernet" => {
                 lines.push(Line::from(""));
                 lines.push(helpers::section_header("Beacons"));

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -39,8 +39,8 @@ pub use node::{
 };
 pub use peer::{ConnectPolicy, PeerAddress, PeerConfig};
 pub use transport::{
-    BleConfig, DirectoryServiceConfig, EthernetConfig, TcpConfig, TorConfig, TransportInstances,
-    TransportsConfig, UdpConfig,
+    BleConfig, DirectoryServiceConfig, EthernetConfig, NymConfig, TcpConfig, TorConfig,
+    TransportInstances, TransportsConfig, UdpConfig,
 };
 
 /// Default config filename.

--- a/src/config/transport.rs
+++ b/src/config/transport.rs
@@ -802,6 +802,77 @@ impl BleConfig {
 }
 
 // ============================================================================
+// Nym Transport Configuration
+// ============================================================================
+
+/// Default Nym SOCKS5 proxy address (nym-socks5-client).
+const DEFAULT_NYM_SOCKS5_ADDR: &str = "127.0.0.1:1080";
+
+/// Default Nym connect timeout in milliseconds (300s — Nym mixnet
+/// SOCKS5 connections require multiple round-trips through 3 mix nodes
+/// with timing obfuscation, which can take several minutes).
+const DEFAULT_NYM_CONNECT_TIMEOUT_MS: u64 = 300_000;
+
+/// Default Nym MTU (same as TCP).
+const DEFAULT_NYM_MTU: u16 = 1400;
+
+/// Default Nym startup timeout in seconds (time to wait for
+/// nym-socks5-client to become ready before giving up).
+const DEFAULT_NYM_STARTUP_TIMEOUT_SECS: u64 = 120;
+
+/// Nym transport instance configuration.
+///
+/// Outbound-only connections through a nym-socks5-client SOCKS5 proxy.
+/// The nym-socks5-client must be running separately (e.g., as a sidecar
+/// process or container).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NymConfig {
+    /// SOCKS5 proxy address (host:port). Defaults to "127.0.0.1:1080".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub socks5_addr: Option<String>,
+
+    /// Outbound connect timeout in milliseconds. Defaults to 300000 (300s).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connect_timeout_ms: Option<u64>,
+
+    /// Default MTU for Nym connections. Defaults to 1400.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mtu: Option<u16>,
+
+    /// Seconds to wait for nym-socks5-client to become ready at startup.
+    /// Defaults to 120.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub startup_timeout_secs: Option<u64>,
+}
+
+impl NymConfig {
+    /// Get the SOCKS5 proxy address. Default: "127.0.0.1:1080".
+    pub fn socks5_addr(&self) -> &str {
+        self.socks5_addr
+            .as_deref()
+            .unwrap_or(DEFAULT_NYM_SOCKS5_ADDR)
+    }
+
+    /// Get the connect timeout in milliseconds. Default: 300000.
+    pub fn connect_timeout_ms(&self) -> u64 {
+        self.connect_timeout_ms
+            .unwrap_or(DEFAULT_NYM_CONNECT_TIMEOUT_MS)
+    }
+
+    /// Get the default MTU. Default: 1400.
+    pub fn mtu(&self) -> u16 {
+        self.mtu.unwrap_or(DEFAULT_NYM_MTU)
+    }
+
+    /// Get the startup timeout in seconds. Default: 120.
+    pub fn startup_timeout_secs(&self) -> u64 {
+        self.startup_timeout_secs
+            .unwrap_or(DEFAULT_NYM_STARTUP_TIMEOUT_SECS)
+    }
+}
+
+// ============================================================================
 // TransportsConfig
 // ============================================================================
 
@@ -827,6 +898,10 @@ pub struct TransportsConfig {
     #[serde(default, skip_serializing_if = "is_transport_empty")]
     pub tor: TransportInstances<TorConfig>,
 
+    /// Nym transport instances.
+    #[serde(default, skip_serializing_if = "is_transport_empty")]
+    pub nym: TransportInstances<NymConfig>,
+
     /// BLE transport instances.
     #[serde(default, skip_serializing_if = "is_transport_empty")]
     pub ble: TransportInstances<BleConfig>,
@@ -844,6 +919,7 @@ impl TransportsConfig {
             && self.ethernet.is_empty()
             && self.tcp.is_empty()
             && self.tor.is_empty()
+            && self.nym.is_empty()
             && self.ble.is_empty()
     }
 
@@ -862,6 +938,9 @@ impl TransportsConfig {
         }
         if !other.tor.is_empty() {
             self.tor = other.tor;
+        }
+        if !other.nym.is_empty() {
+            self.nym = other.nym;
         }
         if !other.ble.is_empty() {
             self.ble = other.ble;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub use identity::{
 };
 
 // Re-export config types
-pub use config::{Config, ConfigError, IdentityConfig, TorConfig, UdpConfig};
+pub use config::{Config, ConfigError, IdentityConfig, NymConfig, TorConfig, UdpConfig};
 pub use upper::config::{DnsConfig, TunConfig};
 
 // Re-export discovery types

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -982,6 +982,26 @@ impl Node {
             transports.push(TransportHandle::Tor(tor));
         }
 
+        // Create Nym transport instances
+        let nym_instances: Vec<_> = self
+            .config()
+            .transports
+            .nym
+            .iter()
+            .map(|(name, config)| (name.map(|s| s.to_string()), config.clone()))
+            .collect();
+
+        for (name, nym_config) in nym_instances {
+            let transport_id = self.allocate_transport_id();
+            let nym = crate::transport::nym::NymTransport::new(
+                transport_id,
+                name,
+                nym_config,
+                packet_tx.clone(),
+            );
+            transports.push(TransportHandle::Nym(nym));
+        }
+
         // Create BLE transport instances
         #[cfg(bluer_available)]
         {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -6,6 +6,7 @@
 
 #[cfg(test)]
 pub mod loopback;
+pub mod nym;
 pub mod tcp;
 pub mod tor;
 pub mod udp;
@@ -22,6 +23,7 @@ use ble::DefaultBleTransport;
 use ethernet::EthernetTransport;
 #[cfg(test)]
 use loopback::LoopbackTransport;
+use nym::NymTransport;
 use secp256k1::XOnlyPublicKey;
 use std::fmt;
 use std::net::SocketAddr;
@@ -257,6 +259,13 @@ impl TransportType {
         name: "loopback",
         connection_oriented: false,
         reliable: true, // in-process channel delivery is lossless
+    };
+
+    /// Nym mixnet transport (via SOCKS5).
+    pub const NYM: TransportType = TransportType {
+        name: "nym",
+        connection_oriented: true,
+        reliable: true,
     };
 
     /// Check if the transport is connectionless.
@@ -879,6 +888,8 @@ pub enum TransportHandle {
     Tcp(TcpTransport),
     /// Tor transport (via SOCKS5).
     Tor(TorTransport),
+    /// Nym mixnet transport (via SOCKS5).
+    Nym(NymTransport),
     /// BLE L2CAP transport.
     #[cfg(target_os = "linux")]
     Ble(DefaultBleTransport),
@@ -896,6 +907,7 @@ impl TransportHandle {
             TransportHandle::Ethernet(t) => t.start_async().await,
             TransportHandle::Tcp(t) => t.start_async().await,
             TransportHandle::Tor(t) => t.start_async().await,
+            TransportHandle::Nym(t) => t.start_async().await,
             #[cfg(target_os = "linux")]
             TransportHandle::Ble(t) => t.start_async().await,
             #[cfg(test)]
@@ -911,6 +923,7 @@ impl TransportHandle {
             TransportHandle::Ethernet(t) => t.stop_async().await,
             TransportHandle::Tcp(t) => t.stop_async().await,
             TransportHandle::Tor(t) => t.stop_async().await,
+            TransportHandle::Nym(t) => t.stop_async().await,
             #[cfg(target_os = "linux")]
             TransportHandle::Ble(t) => t.stop_async().await,
             #[cfg(test)]
@@ -926,6 +939,7 @@ impl TransportHandle {
             TransportHandle::Ethernet(t) => t.send_async(addr, data).await,
             TransportHandle::Tcp(t) => t.send_async(addr, data).await,
             TransportHandle::Tor(t) => t.send_async(addr, data).await,
+            TransportHandle::Nym(t) => t.send_async(addr, data).await,
             #[cfg(target_os = "linux")]
             TransportHandle::Ble(t) => t.send_async(addr, data).await,
             #[cfg(test)]
@@ -941,6 +955,7 @@ impl TransportHandle {
             TransportHandle::Ethernet(t) => t.transport_id(),
             TransportHandle::Tcp(t) => t.transport_id(),
             TransportHandle::Tor(t) => t.transport_id(),
+            TransportHandle::Nym(t) => t.transport_id(),
             #[cfg(target_os = "linux")]
             TransportHandle::Ble(t) => t.transport_id(),
             #[cfg(test)]
@@ -956,6 +971,7 @@ impl TransportHandle {
             TransportHandle::Ethernet(t) => t.name(),
             TransportHandle::Tcp(t) => t.name(),
             TransportHandle::Tor(t) => t.name(),
+            TransportHandle::Nym(t) => t.name(),
             #[cfg(target_os = "linux")]
             TransportHandle::Ble(t) => t.name(),
             #[cfg(test)]
@@ -971,6 +987,7 @@ impl TransportHandle {
             TransportHandle::Ethernet(t) => t.transport_type(),
             TransportHandle::Tcp(t) => t.transport_type(),
             TransportHandle::Tor(t) => t.transport_type(),
+            TransportHandle::Nym(t) => t.transport_type(),
             #[cfg(target_os = "linux")]
             TransportHandle::Ble(t) => t.transport_type(),
             #[cfg(test)]
@@ -986,6 +1003,7 @@ impl TransportHandle {
             TransportHandle::Ethernet(t) => t.state(),
             TransportHandle::Tcp(t) => t.state(),
             TransportHandle::Tor(t) => t.state(),
+            TransportHandle::Nym(t) => t.state(),
             #[cfg(target_os = "linux")]
             TransportHandle::Ble(t) => t.state(),
             #[cfg(test)]
@@ -1001,6 +1019,7 @@ impl TransportHandle {
             TransportHandle::Ethernet(t) => t.mtu(),
             TransportHandle::Tcp(t) => t.mtu(),
             TransportHandle::Tor(t) => t.mtu(),
+            TransportHandle::Nym(t) => t.mtu(),
             #[cfg(target_os = "linux")]
             TransportHandle::Ble(t) => t.mtu(),
             #[cfg(test)]
@@ -1019,6 +1038,7 @@ impl TransportHandle {
             TransportHandle::Ethernet(t) => t.link_mtu(addr),
             TransportHandle::Tcp(t) => t.link_mtu(addr),
             TransportHandle::Tor(t) => t.link_mtu(addr),
+            TransportHandle::Nym(t) => t.link_mtu(addr),
             #[cfg(target_os = "linux")]
             TransportHandle::Ble(t) => t.link_mtu(addr),
             #[cfg(test)]
@@ -1034,6 +1054,7 @@ impl TransportHandle {
             TransportHandle::Ethernet(_) => None,
             TransportHandle::Tcp(t) => t.local_addr(),
             TransportHandle::Tor(_) => None,
+            TransportHandle::Nym(_) => None,
             #[cfg(target_os = "linux")]
             TransportHandle::Ble(_) => None,
             #[cfg(test)]
@@ -1049,6 +1070,7 @@ impl TransportHandle {
             TransportHandle::Ethernet(t) => Some(t.interface_name()),
             TransportHandle::Tcp(_) => None,
             TransportHandle::Tor(_) => None,
+            TransportHandle::Nym(_) => None,
             #[cfg(target_os = "linux")]
             TransportHandle::Ble(_) => None,
             #[cfg(test)]
@@ -1088,6 +1110,7 @@ impl TransportHandle {
             TransportHandle::Ethernet(t) => t.discover(),
             TransportHandle::Tcp(t) => t.discover(),
             TransportHandle::Tor(t) => t.discover(),
+            TransportHandle::Nym(t) => t.discover(),
             #[cfg(target_os = "linux")]
             TransportHandle::Ble(t) => t.discover(),
             #[cfg(test)]
@@ -1103,6 +1126,7 @@ impl TransportHandle {
             TransportHandle::Ethernet(t) => t.auto_connect(),
             TransportHandle::Tcp(t) => t.auto_connect(),
             TransportHandle::Tor(t) => t.auto_connect(),
+            TransportHandle::Nym(t) => t.auto_connect(),
             #[cfg(target_os = "linux")]
             TransportHandle::Ble(t) => t.auto_connect(),
             #[cfg(test)]
@@ -1118,6 +1142,7 @@ impl TransportHandle {
             TransportHandle::Ethernet(t) => t.accept_connections(),
             TransportHandle::Tcp(t) => t.accept_connections(),
             TransportHandle::Tor(t) => t.accept_connections(),
+            TransportHandle::Nym(t) => t.accept_connections(),
             #[cfg(target_os = "linux")]
             TransportHandle::Ble(t) => t.accept_connections(),
             #[cfg(test)]
@@ -1127,7 +1152,7 @@ impl TransportHandle {
 
     /// Initiate a non-blocking connection to a remote address.
     ///
-    /// For connection-oriented transports (TCP, Tor), spawns a background
+    /// For connection-oriented transports (TCP, Tor, Nym), spawns a background
     /// task to establish the connection. For connectionless transports
     /// (UDP, Ethernet), this is a no-op that returns Ok immediately.
     ///
@@ -1139,6 +1164,7 @@ impl TransportHandle {
             TransportHandle::Ethernet(_) => Ok(()), // connectionless
             TransportHandle::Tcp(t) => t.connect_async(addr).await,
             TransportHandle::Tor(t) => t.connect_async(addr).await,
+            TransportHandle::Nym(t) => t.connect_async(addr).await,
             #[cfg(target_os = "linux")]
             TransportHandle::Ble(t) => t.connect_async(addr).await,
             #[cfg(test)]
@@ -1158,6 +1184,7 @@ impl TransportHandle {
             TransportHandle::Ethernet(_) => ConnectionState::Connected,
             TransportHandle::Tcp(t) => t.connection_state_sync(addr),
             TransportHandle::Tor(t) => t.connection_state_sync(addr),
+            TransportHandle::Nym(t) => t.connection_state_sync(addr),
             #[cfg(target_os = "linux")]
             TransportHandle::Ble(t) => t.connection_state_sync(addr),
             #[cfg(test)]
@@ -1167,7 +1194,7 @@ impl TransportHandle {
 
     /// Close a specific connection on this transport.
     ///
-    /// No-op for connectionless transports. For TCP/Tor, removes the
+    /// No-op for connectionless transports. For TCP/Tor/Nym, removes the
     /// connection from the pool and drops the stream.
     pub async fn close_connection(&self, addr: &TransportAddr) {
         match self {
@@ -1176,6 +1203,7 @@ impl TransportHandle {
             TransportHandle::Ethernet(t) => t.close_connection(addr),
             TransportHandle::Tcp(t) => t.close_connection_async(addr).await,
             TransportHandle::Tor(t) => t.close_connection_async(addr).await,
+            TransportHandle::Nym(t) => t.close_connection_async(addr).await,
             #[cfg(target_os = "linux")]
             TransportHandle::Ble(t) => t.close_connection_async(addr).await,
             #[cfg(test)]
@@ -1200,6 +1228,7 @@ impl TransportHandle {
             TransportHandle::Ethernet(_) => TransportCongestion::default(),
             TransportHandle::Tcp(_) => TransportCongestion::default(),
             TransportHandle::Tor(_) => TransportCongestion::default(),
+            TransportHandle::Nym(_) => TransportCongestion::default(),
             #[cfg(target_os = "linux")]
             TransportHandle::Ble(_) => TransportCongestion::default(),
             #[cfg(test)]
@@ -1235,6 +1264,9 @@ impl TransportHandle {
                 serde_json::to_value(t.stats().snapshot()).unwrap_or_default()
             }
             TransportHandle::Tor(t) => {
+                serde_json::to_value(t.stats().snapshot()).unwrap_or_default()
+            }
+            TransportHandle::Nym(t) => {
                 serde_json::to_value(t.stats().snapshot()).unwrap_or_default()
             }
             #[cfg(target_os = "linux")]

--- a/src/transport/nym/mod.rs
+++ b/src/transport/nym/mod.rs
@@ -1,0 +1,840 @@
+//! Nym Mixnet Transport Implementation
+//!
+//! Provides Nym-based transport for FIPS peer communication using the
+//! "Mixnet-As-Proxy" pattern. Traffic is routed through a local
+//! nym-socks5-client SOCKS5 proxy into the Nym mixnet, providing
+//! anonymity via Sphinx packet routing and timing obfuscation.
+//!
+//! ## Architecture
+//!
+//! Outbound-only: connects to remote TCP peers through the local
+//! nym-socks5-client SOCKS5 proxy. Like the Tor transport, reuses FMP
+//! stream framing from `tcp::stream` and follows the same connection
+//! pool pattern. No inbound service is supported.
+
+pub mod stats;
+
+use super::{
+    ConnectionState, DiscoveredPeer, PacketTx, ReceivedPacket, Transport, TransportAddr,
+    TransportError, TransportId, TransportState, TransportType,
+};
+use crate::config::NymConfig;
+use crate::transport::tcp::stream::read_fmp_packet;
+use stats::NymStats;
+
+use futures::FutureExt;
+use socket2::TcpKeepalive;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
+use tokio::net::tcp::OwnedWriteHalf;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
+use tokio_socks::tcp::Socks5Stream;
+use tracing::{debug, info, trace, warn};
+
+// ============================================================================
+// Connection Pool
+// ============================================================================
+
+/// State for a single Nym connection to a peer.
+struct NymConnection {
+    /// Write half of the split stream.
+    writer: Arc<Mutex<OwnedWriteHalf>>,
+    /// Receive task for this connection.
+    recv_task: JoinHandle<()>,
+    /// MTU for this connection.
+    #[allow(dead_code)]
+    mtu: u16,
+    /// When the connection was established.
+    #[allow(dead_code)]
+    established_at: Instant,
+}
+
+/// Shared connection pool.
+type ConnectionPool = Arc<Mutex<HashMap<TransportAddr, NymConnection>>>;
+
+/// A pending background connection attempt.
+struct ConnectingEntry {
+    /// Background task performing SOCKS5 connect + socket configuration.
+    task: JoinHandle<Result<(TcpStream, u16), TransportError>>,
+}
+
+/// Map of addresses with background connection attempts in progress.
+type ConnectingPool = Arc<Mutex<HashMap<TransportAddr, ConnectingEntry>>>;
+
+// ============================================================================
+// Nym Transport
+// ============================================================================
+
+/// Nym mixnet transport for FIPS.
+///
+/// Provides connection-oriented, reliable byte stream delivery through
+/// the Nym mixnet via a local nym-socks5-client SOCKS5 proxy.
+/// Outbound-only — no inbound service.
+pub struct NymTransport {
+    /// Unique transport identifier.
+    transport_id: TransportId,
+    /// Optional instance name (for named instances in config).
+    name: Option<String>,
+    /// Configuration.
+    config: NymConfig,
+    /// Current state.
+    state: TransportState,
+    /// Connection pool: addr -> per-connection state.
+    pool: ConnectionPool,
+    /// Pending connection attempts: addr -> background connect task.
+    connecting: ConnectingPool,
+    /// Channel for delivering received packets to Node.
+    packet_tx: PacketTx,
+    /// Transport statistics.
+    stats: Arc<NymStats>,
+}
+
+impl NymTransport {
+    /// Create a new Nym transport.
+    pub fn new(
+        transport_id: TransportId,
+        name: Option<String>,
+        config: NymConfig,
+        packet_tx: PacketTx,
+    ) -> Self {
+        Self {
+            transport_id,
+            name,
+            config,
+            state: TransportState::Configured,
+            pool: Arc::new(Mutex::new(HashMap::new())),
+            connecting: Arc::new(Mutex::new(HashMap::new())),
+            packet_tx,
+            stats: Arc::new(NymStats::new()),
+        }
+    }
+
+    /// Get the instance name (if configured as a named instance).
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    /// Get the transport statistics.
+    pub fn stats(&self) -> &Arc<NymStats> {
+        &self.stats
+    }
+
+    /// Start the transport asynchronously.
+    ///
+    /// Validates the SOCKS5 proxy address and transitions to Up.
+    /// The nym-socks5-client must already be running and listening
+    /// on the configured address.
+    pub async fn start_async(&mut self) -> Result<(), TransportError> {
+        if !self.state.can_start() {
+            return Err(TransportError::AlreadyStarted);
+        }
+
+        self.state = TransportState::Starting;
+
+        let socks5_addr = self.config.socks5_addr().to_string();
+        validate_host_port(&socks5_addr, "socks5_addr")?;
+
+        // Wait for nym-socks5-client to be ready by probing the SOCKS5 port
+        let ready = self.wait_for_socks5_ready(&socks5_addr).await;
+        if !ready {
+            warn!(
+                transport_id = %self.transport_id,
+                socks5_addr = %socks5_addr,
+                "Nym SOCKS5 client not reachable after waiting — starting anyway \
+                 (connections will fail until it becomes available)"
+            );
+        }
+
+        self.state = TransportState::Up;
+
+        if let Some(ref name) = self.name {
+            info!(
+                name = %name,
+                socks5_addr = %socks5_addr,
+                mtu = self.config.mtu(),
+                "Nym mixnet transport started"
+            );
+        } else {
+            info!(
+                socks5_addr = %socks5_addr,
+                mtu = self.config.mtu(),
+                "Nym mixnet transport started"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Wait for the nym-socks5-client SOCKS5 proxy to become reachable.
+    ///
+    /// Probes the TCP port with exponential backoff. Returns true if the
+    /// proxy is reachable within the timeout, false otherwise.
+    async fn wait_for_socks5_ready(&self, socks5_addr: &str) -> bool {
+        let max_wait = Duration::from_secs(self.config.startup_timeout_secs());
+        let start = Instant::now();
+        let mut delay = Duration::from_secs(1);
+
+        info!(
+            transport_id = %self.transport_id,
+            socks5_addr = %socks5_addr,
+            timeout_secs = max_wait.as_secs(),
+            "Waiting for Nym SOCKS5 client to become ready..."
+        );
+
+        loop {
+            match TcpStream::connect(socks5_addr).await {
+                Ok(_) => {
+                    info!(
+                        transport_id = %self.transport_id,
+                        socks5_addr = %socks5_addr,
+                        elapsed_secs = start.elapsed().as_secs(),
+                        "Nym SOCKS5 client is ready"
+                    );
+                    return true;
+                }
+                Err(e) => {
+                    if start.elapsed() >= max_wait {
+                        warn!(
+                            transport_id = %self.transport_id,
+                            socks5_addr = %socks5_addr,
+                            error = %e,
+                            elapsed_secs = start.elapsed().as_secs(),
+                            "Nym SOCKS5 client not ready after timeout"
+                        );
+                        return false;
+                    }
+                    debug!(
+                        transport_id = %self.transport_id,
+                        socks5_addr = %socks5_addr,
+                        error = %e,
+                        retry_in_secs = delay.as_secs(),
+                        "Nym SOCKS5 client not ready yet, retrying..."
+                    );
+                    tokio::time::sleep(delay).await;
+                    delay = (delay * 2).min(Duration::from_secs(10));
+                }
+            }
+        }
+    }
+
+    /// Stop the transport asynchronously.
+    pub async fn stop_async(&mut self) -> Result<(), TransportError> {
+        if !self.state.is_operational() {
+            return Err(TransportError::NotStarted);
+        }
+
+        // Abort pending connection attempts
+        let mut connecting = self.connecting.lock().await;
+        for (addr, entry) in connecting.drain() {
+            entry.task.abort();
+            debug!(
+                transport_id = %self.transport_id,
+                remote_addr = %addr,
+                "Nym connect aborted (transport stopping)"
+            );
+        }
+        drop(connecting);
+
+        // Close all connections
+        let mut pool = self.pool.lock().await;
+        for (addr, conn) in pool.drain() {
+            conn.recv_task.abort();
+            let _ = conn.recv_task.await;
+            debug!(
+                transport_id = %self.transport_id,
+                remote_addr = %addr,
+                "Nym connection closed (transport stopping)"
+            );
+        }
+        drop(pool);
+
+        self.state = TransportState::Down;
+
+        info!(
+            transport_id = %self.transport_id,
+            "Nym transport stopped"
+        );
+
+        Ok(())
+    }
+
+    /// Send a packet asynchronously.
+    ///
+    /// If no connection exists, performs connect-on-send through the
+    /// Nym SOCKS5 proxy.
+    pub async fn send_async(
+        &self,
+        addr: &TransportAddr,
+        data: &[u8],
+    ) -> Result<usize, TransportError> {
+        if !self.state.is_operational() {
+            return Err(TransportError::NotStarted);
+        }
+
+        // Pre-send MTU check
+        let mtu = self.config.mtu() as usize;
+        if data.len() > mtu {
+            self.stats.record_mtu_exceeded();
+            return Err(TransportError::MtuExceeded {
+                packet_size: data.len(),
+                mtu: self.config.mtu(),
+            });
+        }
+
+        // Get or create connection
+        let writer = {
+            let pool = self.pool.lock().await;
+            pool.get(addr).map(|c| c.writer.clone())
+        };
+
+        let writer = match writer {
+            Some(w) => w,
+            None => {
+                // Connect-on-send
+                self.connect(addr).await?
+            }
+        };
+
+        // Write packet
+        let mut w = writer.lock().await;
+        match w.write_all(data).await {
+            Ok(()) => {
+                self.stats.record_send(data.len());
+                trace!(
+                    transport_id = %self.transport_id,
+                    remote_addr = %addr,
+                    bytes = data.len(),
+                    "Nym packet sent"
+                );
+                Ok(data.len())
+            }
+            Err(e) => {
+                self.stats.record_send_error();
+                drop(w);
+                // Remove failed connection from pool
+                let mut pool = self.pool.lock().await;
+                if let Some(conn) = pool.remove(addr) {
+                    conn.recv_task.abort();
+                }
+                Err(TransportError::SendFailed(format!("{}", e)))
+            }
+        }
+    }
+
+    /// Establish a new connection through the Nym SOCKS5 proxy.
+    async fn connect(
+        &self,
+        addr: &TransportAddr,
+    ) -> Result<Arc<Mutex<OwnedWriteHalf>>, TransportError> {
+        let target_addr = parse_target_addr(addr)?;
+        let proxy_addr = self.config.socks5_addr();
+        let timeout_ms = self.config.connect_timeout_ms();
+
+        info!(
+            transport_id = %self.transport_id,
+            remote_addr = %addr,
+            proxy = %proxy_addr,
+            timeout_secs = timeout_ms / 1000,
+            "Connecting via Nym mixnet SOCKS5 proxy"
+        );
+
+        let connect_start = Instant::now();
+        let socks_result = tokio::time::timeout(Duration::from_millis(timeout_ms), async {
+            match target_addr {
+                TargetAddr::Ip(socket_addr) => Socks5Stream::connect(proxy_addr, socket_addr).await,
+                TargetAddr::Hostname(host, port) => {
+                    Socks5Stream::connect(proxy_addr, (host.as_str(), port)).await
+                }
+            }
+        })
+        .await;
+
+        let stream = match socks_result {
+            Ok(Ok(socks_stream)) => socks_stream.into_inner(),
+            Ok(Err(e)) => {
+                self.stats.record_socks5_error();
+                warn!(
+                    transport_id = %self.transport_id,
+                    remote_addr = %addr,
+                    error = %e,
+                    elapsed_secs = connect_start.elapsed().as_secs(),
+                    "Nym SOCKS5 connection failed"
+                );
+                return Err(TransportError::ConnectionRefused);
+            }
+            Err(_) => {
+                self.stats.record_connect_timeout();
+                warn!(
+                    transport_id = %self.transport_id,
+                    remote_addr = %addr,
+                    timeout_secs = timeout_ms / 1000,
+                    "Nym SOCKS5 connection timed out"
+                );
+                return Err(TransportError::Timeout);
+            }
+        };
+
+        // Configure socket options via socket2
+        let std_stream = stream
+            .into_std()
+            .map_err(|e| TransportError::StartFailed(format!("into_std: {}", e)))?;
+        configure_socket(&std_stream)?;
+
+        // Convert back to tokio
+        let stream = TcpStream::from_std(std_stream)
+            .map_err(|e| TransportError::StartFailed(format!("from_std: {}", e)))?;
+
+        // Split and spawn receive task
+        let (read_half, write_half) = stream.into_split();
+        let writer = Arc::new(Mutex::new(write_half));
+
+        let transport_id = self.transport_id;
+        let packet_tx = self.packet_tx.clone();
+        let pool = self.pool.clone();
+        let recv_stats = self.stats.clone();
+        let remote_addr = addr.clone();
+        let mtu = self.config.mtu();
+
+        let recv_task = tokio::spawn(async move {
+            nym_receive_loop(
+                read_half,
+                transport_id,
+                remote_addr.clone(),
+                packet_tx,
+                pool,
+                mtu,
+                recv_stats,
+            )
+            .await;
+        });
+
+        let conn = NymConnection {
+            writer: writer.clone(),
+            recv_task,
+            mtu,
+            established_at: Instant::now(),
+        };
+
+        let mut pool = self.pool.lock().await;
+        pool.insert(addr.clone(), conn);
+
+        self.stats.record_connection_established();
+
+        info!(
+            transport_id = %self.transport_id,
+            remote_addr = %addr,
+            elapsed_secs = connect_start.elapsed().as_secs(),
+            "Nym mixnet connection established via SOCKS5"
+        );
+
+        Ok(writer)
+    }
+
+    /// Initiate a non-blocking connection to a remote address.
+    pub async fn connect_async(&self, addr: &TransportAddr) -> Result<(), TransportError> {
+        if !self.state.is_operational() {
+            return Err(TransportError::NotStarted);
+        }
+
+        // Already established?
+        {
+            let pool = self.pool.lock().await;
+            if pool.contains_key(addr) {
+                return Ok(());
+            }
+        }
+
+        // Already connecting?
+        {
+            let connecting = self.connecting.lock().await;
+            if connecting.contains_key(addr) {
+                return Ok(());
+            }
+        }
+
+        let target_addr = parse_target_addr(addr)?;
+        let proxy_addr = self.config.socks5_addr().to_string();
+        let timeout_ms = self.config.connect_timeout_ms();
+        let transport_id = self.transport_id;
+        let remote_addr = addr.clone();
+        let config = self.config.clone();
+
+        info!(
+            transport_id = %transport_id,
+            remote_addr = %remote_addr,
+            timeout_ms,
+            "Initiating background Nym SOCKS5 connect"
+        );
+
+        let task = tokio::spawn(async move {
+            let connect_start = Instant::now();
+            info!(
+                transport_id = %transport_id,
+                remote_addr = %remote_addr,
+                proxy = %proxy_addr,
+                timeout_secs = timeout_ms / 1000,
+                "Nym SOCKS5 CONNECT starting (this may take several minutes through mixnet)"
+            );
+
+            let socks_result = tokio::time::timeout(Duration::from_millis(timeout_ms), async {
+                match target_addr {
+                    TargetAddr::Ip(socket_addr) => {
+                        Socks5Stream::connect(proxy_addr.as_str(), socket_addr).await
+                    }
+                    TargetAddr::Hostname(host, port) => {
+                        Socks5Stream::connect(proxy_addr.as_str(), (host.as_str(), port)).await
+                    }
+                }
+            })
+            .await;
+
+            let stream = match socks_result {
+                Ok(Ok(socks_stream)) => {
+                    info!(
+                        transport_id = %transport_id,
+                        remote_addr = %remote_addr,
+                        elapsed_secs = connect_start.elapsed().as_secs(),
+                        "Nym SOCKS5 CONNECT succeeded"
+                    );
+                    socks_stream.into_inner()
+                }
+                Ok(Err(e)) => {
+                    warn!(
+                        transport_id = %transport_id,
+                        remote_addr = %remote_addr,
+                        error = %e,
+                        elapsed_secs = connect_start.elapsed().as_secs(),
+                        "Background Nym SOCKS5 connect failed"
+                    );
+                    return Err(TransportError::ConnectionRefused);
+                }
+                Err(_) => {
+                    warn!(
+                        transport_id = %transport_id,
+                        remote_addr = %remote_addr,
+                        timeout_secs = timeout_ms / 1000,
+                        elapsed_secs = connect_start.elapsed().as_secs(),
+                        "Background Nym SOCKS5 connect timed out after {}s",
+                        connect_start.elapsed().as_secs()
+                    );
+                    return Err(TransportError::Timeout);
+                }
+            };
+
+            // Configure socket options via socket2
+            let std_stream = stream
+                .into_std()
+                .map_err(|e| TransportError::StartFailed(format!("into_std: {}", e)))?;
+            configure_socket(&std_stream)?;
+
+            let mtu = config.mtu();
+
+            // Convert back to tokio
+            let stream = TcpStream::from_std(std_stream)
+                .map_err(|e| TransportError::StartFailed(format!("from_std: {}", e)))?;
+
+            Ok((stream, mtu))
+        });
+
+        let mut connecting = self.connecting.lock().await;
+        connecting.insert(addr.clone(), ConnectingEntry { task });
+
+        Ok(())
+    }
+
+    /// Query the state of a connection to a remote address.
+    pub fn connection_state_sync(&self, addr: &TransportAddr) -> ConnectionState {
+        // Check established pool first
+        if let Ok(pool) = self.pool.try_lock() {
+            if pool.contains_key(addr) {
+                return ConnectionState::Connected;
+            }
+        } else {
+            return ConnectionState::Connecting;
+        }
+
+        // Check connecting pool
+        let mut connecting = match self.connecting.try_lock() {
+            Ok(c) => c,
+            Err(_) => return ConnectionState::Connecting,
+        };
+
+        let entry = match connecting.get_mut(addr) {
+            Some(e) => e,
+            None => return ConnectionState::None,
+        };
+
+        if !entry.task.is_finished() {
+            return ConnectionState::Connecting;
+        }
+
+        // Task is done — take the result
+        let addr_clone = addr.clone();
+        let task = connecting.remove(&addr_clone).unwrap().task;
+
+        match task.now_or_never() {
+            Some(Ok(Ok((stream, mtu)))) => {
+                self.promote_connection(addr, stream, mtu);
+                ConnectionState::Connected
+            }
+            Some(Ok(Err(e))) => ConnectionState::Failed(format!("{}", e)),
+            Some(Err(e)) => ConnectionState::Failed(format!("task failed: {}", e)),
+            None => ConnectionState::Connecting,
+        }
+    }
+
+    /// Promote a completed background connection to the established pool.
+    fn promote_connection(&self, addr: &TransportAddr, stream: TcpStream, mtu: u16) {
+        let (read_half, write_half) = stream.into_split();
+        let writer = Arc::new(Mutex::new(write_half));
+
+        let transport_id = self.transport_id;
+        let packet_tx = self.packet_tx.clone();
+        let pool = self.pool.clone();
+        let recv_stats = self.stats.clone();
+        let remote_addr = addr.clone();
+
+        let recv_task = tokio::spawn(async move {
+            nym_receive_loop(
+                read_half,
+                transport_id,
+                remote_addr.clone(),
+                packet_tx,
+                pool,
+                mtu,
+                recv_stats,
+            )
+            .await;
+        });
+
+        let conn = NymConnection {
+            writer,
+            recv_task,
+            mtu,
+            established_at: Instant::now(),
+        };
+
+        if let Ok(mut pool) = self.pool.try_lock() {
+            pool.insert(addr.clone(), conn);
+            self.stats.record_connection_established();
+            debug!(
+                transport_id = %self.transport_id,
+                remote_addr = %addr,
+                "Nym connection established (background connect)"
+            );
+        } else {
+            conn.recv_task.abort();
+            warn!(
+                transport_id = %self.transport_id,
+                remote_addr = %addr,
+                "Failed to promote Nym connection (pool locked)"
+            );
+        }
+    }
+
+    /// Close a specific connection asynchronously.
+    pub async fn close_connection_async(&self, addr: &TransportAddr) {
+        let mut pool = self.pool.lock().await;
+        if let Some(conn) = pool.remove(addr) {
+            conn.recv_task.abort();
+            debug!(
+                transport_id = %self.transport_id,
+                remote_addr = %addr,
+                "Nym connection closed"
+            );
+        }
+    }
+}
+
+impl Transport for NymTransport {
+    fn transport_id(&self) -> TransportId {
+        self.transport_id
+    }
+
+    fn transport_type(&self) -> &TransportType {
+        &TransportType::NYM
+    }
+
+    fn state(&self) -> TransportState {
+        self.state
+    }
+
+    fn mtu(&self) -> u16 {
+        self.config.mtu()
+    }
+
+    fn link_mtu(&self, _addr: &TransportAddr) -> u16 {
+        self.config.mtu()
+    }
+
+    fn start(&mut self) -> Result<(), TransportError> {
+        Err(TransportError::NotSupported(
+            "use start_async() for Nym transport".into(),
+        ))
+    }
+
+    fn stop(&mut self) -> Result<(), TransportError> {
+        Err(TransportError::NotSupported(
+            "use stop_async() for Nym transport".into(),
+        ))
+    }
+
+    fn send(&self, _addr: &TransportAddr, _data: &[u8]) -> Result<(), TransportError> {
+        Err(TransportError::NotSupported(
+            "use send_async() for Nym transport".into(),
+        ))
+    }
+
+    fn discover(&self) -> Result<Vec<DiscoveredPeer>, TransportError> {
+        Ok(Vec::new())
+    }
+
+    fn accept_connections(&self) -> bool {
+        false
+    }
+}
+
+// ============================================================================
+// Address Parsing
+// ============================================================================
+
+/// Target address for the SOCKS5 CONNECT request.
+#[derive(Clone, Debug)]
+enum TargetAddr {
+    /// Numeric IP:port.
+    Ip(SocketAddr),
+    /// Hostname:port (DNS resolved by the exit node).
+    Hostname(String, u16),
+}
+
+/// Parse a TransportAddr string into a target address.
+fn parse_target_addr(addr: &TransportAddr) -> Result<TargetAddr, TransportError> {
+    let s = addr.as_str().ok_or_else(|| {
+        TransportError::InvalidAddress("Nym address must be a valid UTF-8 string".into())
+    })?;
+
+    if let Ok(socket_addr) = s.parse::<SocketAddr>() {
+        Ok(TargetAddr::Ip(socket_addr))
+    } else {
+        let (host, port_str) = s.rsplit_once(':').ok_or_else(|| {
+            TransportError::InvalidAddress(format!("invalid address (expected host:port): {}", s))
+        })?;
+        let port: u16 = port_str
+            .parse()
+            .map_err(|_| TransportError::InvalidAddress(format!("invalid port: {}", s)))?;
+        Ok(TargetAddr::Hostname(host.to_string(), port))
+    }
+}
+
+// ============================================================================
+// Receive Loop (per-connection)
+// ============================================================================
+
+/// Per-connection Nym receive loop.
+async fn nym_receive_loop(
+    mut reader: tokio::net::tcp::OwnedReadHalf,
+    transport_id: TransportId,
+    remote_addr: TransportAddr,
+    packet_tx: PacketTx,
+    pool: ConnectionPool,
+    mtu: u16,
+    stats: Arc<NymStats>,
+) {
+    debug!(
+        transport_id = %transport_id,
+        remote_addr = %remote_addr,
+        "Nym receive loop starting"
+    );
+
+    loop {
+        match read_fmp_packet(&mut reader, mtu).await {
+            Ok(data) => {
+                stats.record_recv(data.len());
+
+                trace!(
+                    transport_id = %transport_id,
+                    remote_addr = %remote_addr,
+                    bytes = data.len(),
+                    "Nym packet received"
+                );
+
+                let packet = ReceivedPacket::new(transport_id, remote_addr.clone(), data);
+
+                if packet_tx.send(packet).await.is_err() {
+                    debug!(
+                        transport_id = %transport_id,
+                        "Packet channel closed, stopping Nym receive loop"
+                    );
+                    break;
+                }
+            }
+            Err(e) => {
+                stats.record_recv_error();
+                debug!(
+                    transport_id = %transport_id,
+                    remote_addr = %remote_addr,
+                    error = %e,
+                    "Nym receive error, removing connection"
+                );
+                break;
+            }
+        }
+    }
+
+    // Clean up: remove ourselves from the pool
+    let mut pool_guard = pool.lock().await;
+    pool_guard.remove(&remote_addr);
+
+    debug!(
+        transport_id = %transport_id,
+        remote_addr = %remote_addr,
+        "Nym receive loop stopped"
+    );
+}
+
+// ============================================================================
+// Socket Configuration
+// ============================================================================
+
+/// Configure socket options on a SOCKS5-connected stream.
+fn configure_socket(stream: &std::net::TcpStream) -> Result<(), TransportError> {
+    let socket = socket2::SockRef::from(stream);
+
+    // TCP_NODELAY — always enable for FIPS (latency-sensitive protocol messages)
+    socket
+        .set_tcp_nodelay(true)
+        .map_err(|e| TransportError::StartFailed(format!("set nodelay: {}", e)))?;
+
+    // TCP keepalive (30s, matching TCP transport)
+    let keepalive = TcpKeepalive::new().with_time(Duration::from_secs(30));
+    socket
+        .set_tcp_keepalive(&keepalive)
+        .map_err(|e| TransportError::StartFailed(format!("set keepalive: {}", e)))?;
+
+    Ok(())
+}
+
+// ============================================================================
+// Address Validation
+// ============================================================================
+
+/// Validate that a string is a valid host:port address.
+fn validate_host_port(addr: &str, field: &str) -> Result<(), TransportError> {
+    let parts: Vec<&str> = addr.rsplitn(2, ':').collect();
+    if parts.len() != 2 {
+        return Err(TransportError::InvalidAddress(format!(
+            "{} must be host:port, got: {}",
+            field, addr
+        )));
+    }
+    let _port: u16 = parts[0].parse().map_err(|_| {
+        TransportError::InvalidAddress(format!("{} has invalid port: {}", field, addr))
+    })?;
+    Ok(())
+}

--- a/src/transport/nym/stats.rs
+++ b/src/transport/nym/stats.rs
@@ -1,0 +1,128 @@
+//! Nym transport statistics.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::Serialize;
+
+/// Statistics for a Nym transport instance.
+///
+/// Uses atomic counters for lock-free updates from per-connection
+/// receive loops and the send path concurrently.
+pub struct NymStats {
+    pub packets_sent: AtomicU64,
+    pub bytes_sent: AtomicU64,
+    pub packets_recv: AtomicU64,
+    pub bytes_recv: AtomicU64,
+    pub send_errors: AtomicU64,
+    pub recv_errors: AtomicU64,
+    pub mtu_exceeded: AtomicU64,
+    pub connections_established: AtomicU64,
+    pub connect_timeouts: AtomicU64,
+    pub connect_refused: AtomicU64,
+    pub socks5_errors: AtomicU64,
+}
+
+impl NymStats {
+    /// Create a new stats instance with all counters at zero.
+    pub fn new() -> Self {
+        Self {
+            packets_sent: AtomicU64::new(0),
+            bytes_sent: AtomicU64::new(0),
+            packets_recv: AtomicU64::new(0),
+            bytes_recv: AtomicU64::new(0),
+            send_errors: AtomicU64::new(0),
+            recv_errors: AtomicU64::new(0),
+            mtu_exceeded: AtomicU64::new(0),
+            connections_established: AtomicU64::new(0),
+            connect_timeouts: AtomicU64::new(0),
+            connect_refused: AtomicU64::new(0),
+            socks5_errors: AtomicU64::new(0),
+        }
+    }
+
+    /// Record a successful send.
+    pub fn record_send(&self, bytes: usize) {
+        self.packets_sent.fetch_add(1, Ordering::Relaxed);
+        self.bytes_sent.fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+
+    /// Record a successful receive.
+    pub fn record_recv(&self, bytes: usize) {
+        self.packets_recv.fetch_add(1, Ordering::Relaxed);
+        self.bytes_recv.fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+
+    /// Record a send error.
+    pub fn record_send_error(&self) {
+        self.send_errors.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a receive error.
+    pub fn record_recv_error(&self) {
+        self.recv_errors.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record an MTU exceeded rejection.
+    pub fn record_mtu_exceeded(&self) {
+        self.mtu_exceeded.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a successful outbound connection.
+    pub fn record_connection_established(&self) {
+        self.connections_established.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a connect timeout.
+    pub fn record_connect_timeout(&self) {
+        self.connect_timeouts.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a connection refused.
+    pub fn record_connect_refused(&self) {
+        self.connect_refused.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a SOCKS5 protocol error.
+    pub fn record_socks5_error(&self) {
+        self.socks5_errors.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Take a snapshot of all counters.
+    pub fn snapshot(&self) -> NymStatsSnapshot {
+        NymStatsSnapshot {
+            packets_sent: self.packets_sent.load(Ordering::Relaxed),
+            bytes_sent: self.bytes_sent.load(Ordering::Relaxed),
+            packets_recv: self.packets_recv.load(Ordering::Relaxed),
+            bytes_recv: self.bytes_recv.load(Ordering::Relaxed),
+            send_errors: self.send_errors.load(Ordering::Relaxed),
+            recv_errors: self.recv_errors.load(Ordering::Relaxed),
+            mtu_exceeded: self.mtu_exceeded.load(Ordering::Relaxed),
+            connections_established: self.connections_established.load(Ordering::Relaxed),
+            connect_timeouts: self.connect_timeouts.load(Ordering::Relaxed),
+            connect_refused: self.connect_refused.load(Ordering::Relaxed),
+            socks5_errors: self.socks5_errors.load(Ordering::Relaxed),
+        }
+    }
+}
+
+impl Default for NymStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Point-in-time snapshot of Nym stats (non-atomic, copyable).
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct NymStatsSnapshot {
+    pub packets_sent: u64,
+    pub bytes_sent: u64,
+    pub packets_recv: u64,
+    pub bytes_recv: u64,
+    pub send_errors: u64,
+    pub recv_errors: u64,
+    pub mtu_exceeded: u64,
+    pub connections_established: u64,
+    pub connect_timeouts: u64,
+    pub connect_refused: u64,
+    pub socks5_errors: u64,
+}


### PR DESCRIPTION
## Summary

I worked on this during the SEC-07 cohort and believe that it is good to have many transports in FIPS.
Mixnet is a good alternative to the TOR. But we shouldn't stop on this. 

This PR add the mixnet transport only. In a next PR I'll add the sidecar example for testing the transport in docker in the same way as other examples in a repo.

Since the SEC cohort there were few buts in transport and example. They were fixed and tested.

BR,
oleksky

===


Adds a **Nym mixnet transport** — a new transport instance type that tunnels FIPS peer connections through a local `nym-socks5-client` SOCKS5 proxy into the [Nym](https://nym.com/) mixnet, providing Sphinx-routed anonymity and timing obfuscation for peer links.

It is structurally identical to the existing **Tor SOCKS5 transport**: outbound-only, FMP-v0 framing reused from the TCP transport (`tcp::stream::read_fmp_packet`), so an existing TCP-listening peer is reachable as-is over Nym from a node configured with a `transports.nym` block. The `nym-socks5-client` runs separately (sidecar process or container); FIPS only ever sees a SOCKS5 endpoint.

## What's in it

**New files**
- `src/transport/nym/mod.rs` — `NymTransport`: SOCKS5 connection pool, connect-on-send, exponential-backoff readiness probe, FMP framing.
- `src/transport/nym/stats.rs` — `NymStats` atomic counters, serialized into the control-query JSON surface.

**Wiring (additive — no existing behavior changed)**
- `src/transport/mod.rs` — `pub mod nym`, `TransportType::NYM`, `TransportHandle::Nym(..)` variant + dispatch arms. Not platform-gated (works wherever the SOCKS5 client runs).
- `src/config/transport.rs` — `NymConfig` (`socks5_addr`, `connect_timeout_ms`, `mtu`, `startup_timeout_secs`) + `TransportsConfig` merge/empty handling.
- `src/config/mod.rs`, `src/lib.rs` — `pub use NymConfig`.
- `src/node/mod.rs` — instantiate Nym transports at node startup (after the Tor block).
- `src/bin/fipstop/ui/transports.rs` — `"nym"` arm in the transport-detail pane.

## Config

```yaml
transports:
  nym:
    socks5_addr: "127.0.0.1:1080"   # nym-socks5-client SOCKS5 endpoint
    startup_timeout_secs: 120
peers:
  - npub: "<peer-npub>"
    addresses:
      - transport: nym
        addr: "<peer-host>:<tcp-port>"   # peer's TCP endpoint; Nym tunnels TCP
    connect_policy: auto_connect
```

## Testing

- `cargo build --release`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt --check` all green (Linux/amd64 and Linux/arm64).
- Verified end-to-end against a public TCP-listening peer: the node connects through a live Nym service provider, exchanges tree/bloom routing, and carries the data plane (ICMPv6 + sessions) at mixnet latency (~1–2 s RTT vs ~50 ms direct), with the direct route firewalled off to prove traffic crosses the mixnet.

A single-container demo (FIPS + nym-socks5-client + strfry relay) exists on the fork but is intentionally **not** included here to keep this PR focused on the transport; happy to open it separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)