### PR TITLE
Add a Nix flake for reproducible from-source builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,100 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1781527054,
+        "narHash": "sha256-1fX9ev2Fh5QoKQ41G9dYutjo5j/jywu6tZse5Eb1Ck4=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "8c2e51dffefc040a21975da7abf6f252c8c9b783",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781453968,
+        "narHash": "sha256-+V3nK4pCngbmgyVGXY6Kkrlevp4ocPkJJLf2aqwkDNA=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "cc272809a173c2c11d0e479d639c811c1eacf049",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,128 @@
+{
+  description = "FIPS — a distributed, decentralized network routing protocol for mesh nodes connecting over arbitrary transports";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      fenix,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        # Honor the toolchain the repo pins in rust-toolchain.toml
+        # (channel 1.94.1 + rustfmt, clippy) so Nix builds match CI and the
+        # AUR/Debian packaging exactly, including the edition-2024 frontend.
+        rustToolchain = fenix.packages.${system}.fromToolchainFile {
+          file = ./rust-toolchain.toml;
+          sha256 = "sha256-zC8E38iDVJ1oPIzCqTk/Ujo9+9kx9dXq7wAwPMpkpg0=";
+        };
+
+        rustPlatform = pkgs.makeRustPlatform {
+          cargo = rustToolchain;
+          rustc = rustToolchain;
+        };
+
+        cargoToml = pkgs.lib.importTOML ./Cargo.toml;
+
+        # libdbus-sys (pulled in transitively by `bluer`, Linux/glibc only)
+        # runs `bindgen` against the system D-Bus headers at build time.
+        nativeBuildInputs = [
+          pkgs.pkg-config
+          rustPlatform.bindgenHook # sets LIBCLANG_PATH + clang for bindgen
+        ];
+
+        buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [
+          pkgs.dbus # libdbus-1.so.3, linked via bluer→libdbus-sys
+          pkgs.stdenv.cc.cc.lib # libgcc_s.so.1, needed by every Rust binary
+        ];
+
+        fips = rustPlatform.buildRustPackage {
+          pname = "fips";
+          version = cargoToml.package.version;
+
+          src = pkgs.lib.cleanSourceWith {
+            src = ./.;
+            # Drop the build dir and the usual editor/VCS noise so the source
+            # hash is stable and unrelated edits don't trigger rebuilds.
+            filter =
+              path: type:
+              (pkgs.lib.cleanSourceFilter path type) && (baseNameOf path != "target");
+          };
+
+          cargoLock.lockFile = ./Cargo.lock;
+
+          inherit buildInputs;
+
+          # autoPatchelfHook rewrites the RPATH of the built binaries so the
+          # daemon finds libdbus-1.so.3 (linked via bluer→libdbus-sys) in the
+          # Nix store at runtime — without it the `fips` binary fails to load
+          # on NixOS where there is no global /usr/lib.
+          nativeBuildInputs =
+            nativeBuildInputs ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
+
+          # The test suite exercises TUN devices, raw sockets and mDNS, none of
+          # which exist in the build sandbox. The AUR/Debian packaging likewise
+          # ships the release binaries without running the integration tests
+          # here, so keep the package build hermetic and skip them.
+          doCheck = false;
+
+          meta = {
+            description = cargoToml.package.description;
+            homepage = cargoToml.package.homepage;
+            license = pkgs.lib.licenses.mit;
+            mainProgram = "fips";
+            platforms = pkgs.lib.platforms.linux ++ pkgs.lib.platforms.darwin;
+          };
+        };
+
+        mkApp = name: {
+          type = "app";
+          program = "${fips}/bin/${name}";
+          meta.description = "Run the ${name} binary from the FIPS package";
+        };
+      in
+      {
+        packages = {
+          default = fips;
+          fips = fips;
+        };
+
+        apps = {
+          default = mkApp "fips";
+          fips = mkApp "fips";
+          fipsctl = mkApp "fipsctl";
+          fips-gateway = mkApp "fips-gateway";
+          fipstop = mkApp "fipstop";
+        };
+
+        # `nix flake check` builds the package (and thus validates the flake on
+        # the current system).
+        checks.fips = fips;
+
+        devShells.default = pkgs.mkShell {
+          inherit buildInputs;
+          nativeBuildInputs = nativeBuildInputs ++ [
+            rustToolchain
+            pkgs.cargo-edit
+          ];
+          # Point rust-analyzer at the matching std sources.
+          RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+        };
+
+        formatter = pkgs.nixfmt;
+      }
+    );
+}

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -177,6 +177,27 @@ yay -S fips        # release build from latest tag
 See [aur/README.md](aur/README.md) for AUR publication instructions
 and maintainer guide.
 
+### Nix / NixOS (flake)
+
+A [flake](../flake.nix) at the project root builds all four binaries
+(`fips`, `fipsctl`, `fips-gateway`, `fipstop`) from source. It pins the
+exact toolchain from `rust-toolchain.toml` via
+[fenix](https://github.com/nix-community/fenix) and wires up the
+build-time native dependencies (`libclang` for `bindgen`, plus `dbus`
+and `pkg-config` for BLE), so it needs no system setup beyond Nix with
+flakes enabled.
+
+```sh
+nix build .#fips          # build the package (all four binaries)
+nix run .#fips -- --help  # run a binary directly
+nix run .#fipsctl -- status
+nix develop               # dev shell with the pinned toolchain + cargo-edit
+nix flake check           # build + validate the flake
+```
+
+Add to a NixOS configuration via the flake's `packages.<system>.fips`
+output, e.g. `environment.systemPackages = [ fips.packages.${system}.default ];`.
+
 ## Shared Assets
 
 `common/` contains assets used across packaging formats:


### PR DESCRIPTION
## Summary

Adds a Nix flake at the project root so FIPS can be built and run on Nix /
NixOS systems straight from source, joining the existing packaging formats
(deb, AUR, systemd tarball, OpenWrt, macOS, Windows).

The flake builds all four binaries — `fips`, `fipsctl`, `fips-gateway`,
`fipstop` — and pins the **exact** toolchain declared in
`rust-toolchain.toml` (Rust 1.94.1 + rustfmt/clippy, edition 2024) via
[fenix](https://github.com/nix-community/fenix), so Nix builds match CI and
the AUR/Debian packaging rather than drifting to whatever `rustc` nixpkgs
happens to ship.

## What's included

- **`flake.nix` / `flake.lock`** — pinned inputs (nixpkgs, flake-utils, fenix).
- **Native deps wired up** to match the source tree's build requirements:
  - `pkg-config` + `bindgenHook` (libclang) for the `rustables` / `libdbus-sys`
    bindgen step.
  - `dbus` for `bluer`'s BLE support.
  - `autoPatchelfHook` to rewrite binary RPATHs so the daemon resolves
    `libdbus-1.so.3` and `libgcc_s.so.1` from the Nix store at runtime.
- **Outputs:**
  - `packages.{default,fips}`
  - `apps.{fips,fipsctl,fips-gateway,fipstop}`
  - `checks.fips`
  - `devShells.default` (pinned toolchain + `cargo-edit`)
- **Docs** — a Nix/NixOS section added to `packaging/README.md` in the same
  per-format style as the other entries.

## Design notes

- **Why `autoPatchelfHook`:** without it, `fips` builds fine but fails at
  runtime on NixOS with `libdbus-1.so.3: cannot open shared object file`,
  since NixOS has no global `/usr/lib`. The hook gives a *build-time*
  guarantee that every dynamic dependency resolves.
- **Tests are skipped in the package build** (`doCheck = false`): the suite
  exercises TUN devices, raw sockets, and mDNS that aren't available in the
  build sandbox, mirroring what the AUR and Debian packaging already do.

## Verification

Built and exercised end-to-end in a pure Nix store (`nixos/nix` container,
no global `/usr/lib` — i.e. NixOS-equivalent runtime linking), against the
committed `flake.lock`:

- `nix build .#fips` — all four binaries compile and link.
- `auto-patchelf: 0 dependencies could not be satisfied`.
- All four binaries run and report the correct version (`0.4.0-dev`,
  `x86_64-unknown-linux-gnu`).
- `nix flake check` — **all checks passed**.
- `nix develop` exposes exactly `rustc/cargo 1.94.1` and `clippy 0.1.94`.

## Notes

- The `darwin` platform is declared in `meta.platforms` (the source supports
  macOS), but verification here covered `x86_64-linux` / NixOS specifically.
- Might push another update so the flake can support both stable and dev builds,  