### PR TITLE
fix(tun): loop back self-addressed packets for local delivery

### DIFF
--- a/src/upper/tun.rs
+++ b/src/upper/tun.rs
@@ -704,6 +704,19 @@ fn handle_tun_packet(
 
     // Check if destination is a FIPS address (fd::/8 prefix)
     if packet[24] == crate::identity::FIPS_ADDRESS_PREFIX {
+        // Loopback: a packet to our own mesh address must be delivered
+        // locally, not pushed into the mesh (we have no session/route to
+        // ourselves, so it would just be dropped). Hairpin it back to the TUN
+        // writer for inbound delivery. macOS utun egresses self-traffic into
+        // this reader; Linux loops it via `lo` first, so this never fires there.
+        if packet[24..40] == *our_addr.as_bytes() {
+            trace!(name = %name, "Hairpinning self-addressed packet back to TUN (loopback)");
+            if tun_tx.send(packet.to_vec()).is_err() {
+                return false; // Channel closed, shutdown
+            }
+            return true;
+        }
+
         // Per-destination clamp: if discovery has learned a smaller path
         // MTU for this destination, tighten the ceiling for this flow.
         let effective_max_mss = per_flow_max_mss(path_mtu_lookup, &packet[24..40], max_mss);
@@ -1518,6 +1531,88 @@ mod tests {
         lookup.write().unwrap().insert(b, 1452);
         assert_eq!(per_flow_max_mss(&lookup, a.as_bytes(), 1360), 1143);
         assert_eq!(per_flow_max_mss(&lookup, b.as_bytes(), 1360), 1315);
+    }
+
+    // ========================================================================
+    // handle_tun_packet — self-addressed loopback hairpin
+    //
+    // A packet destined for our own mesh address must be delivered back to
+    // the local stack via the TUN writer, never pushed into the mesh (there
+    // is no session/route to ourselves). On macOS the kernel egresses such
+    // self-traffic down the utun into the reader, so the daemon has to loop
+    // it back itself.
+    // ========================================================================
+
+    /// Build a minimal 40-byte IPv6 packet (no upper-layer payload) addressed
+    /// to `dst`, sourced from a distinct fips address.
+    fn ipv6_packet_to(dst: &FipsAddress) -> Vec<u8> {
+        let mut pkt = vec![0u8; 40];
+        pkt[0] = 0x60; // version 6
+        pkt[6] = 59; // next header = No Next Header (skips MSS clamp)
+        pkt[7] = 64; // hop limit
+        pkt[8] = crate::identity::FIPS_ADDRESS_PREFIX; // src in fd::/8
+        pkt[24..40].copy_from_slice(dst.as_bytes()); // dst
+        pkt
+    }
+
+    #[test]
+    fn self_addressed_packet_is_hairpinned_to_tun() {
+        let our_addr = fips_addr_with_node_byte(0x55);
+        let (tun_tx, tun_rx) = mpsc::channel::<Vec<u8>>();
+        let (outbound_tx, mut outbound_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
+        let lookup = empty_lookup();
+        let mut pkt = ipv6_packet_to(&our_addr);
+
+        assert!(handle_tun_packet(
+            &mut pkt,
+            1360,
+            "test0",
+            our_addr,
+            &tun_tx,
+            &outbound_tx,
+            &lookup,
+        ));
+
+        // Delivered locally via the TUN writer...
+        let looped = tun_rx
+            .try_recv()
+            .expect("self-addressed packet should be hairpinned to the TUN");
+        assert_eq!(&looped[24..40], our_addr.as_bytes());
+        // ...and never handed to the mesh.
+        assert!(
+            outbound_rx.try_recv().is_err(),
+            "self-addressed packet must not be pushed into the mesh"
+        );
+    }
+
+    #[test]
+    fn other_fips_packet_goes_to_mesh() {
+        let our_addr = fips_addr_with_node_byte(0x55);
+        let peer = fips_addr_with_node_byte(0x66);
+        let (tun_tx, tun_rx) = mpsc::channel::<Vec<u8>>();
+        let (outbound_tx, mut outbound_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
+        let lookup = empty_lookup();
+        let mut pkt = ipv6_packet_to(&peer);
+
+        assert!(handle_tun_packet(
+            &mut pkt,
+            1360,
+            "test0",
+            our_addr,
+            &tun_tx,
+            &outbound_tx,
+            &lookup,
+        ));
+
+        // A non-self fips destination is routed into the mesh, not looped back.
+        assert!(
+            outbound_rx.try_recv().is_ok(),
+            "non-self fips destination should be sent to the mesh"
+        );
+        assert!(
+            tun_rx.try_recv().is_err(),
+            "non-self fips destination must not be hairpinned"
+        );
     }
 
     // ========================================================================


### PR DESCRIPTION
## Problem

Reaching the local node at its own mesh address — `ping6 <our-addr>`, `ping6 <our-npub>.fips`, or connecting a local app to a service bound on our own mesh IPv6 — failed with 100% loss on macOS, even though the address is bound and the routing table shows a host route to `lo0`.

macOS point-to-point `utun` interfaces egress self-addressed traffic *down the tunnel* into the daemon's TUN reader rather than looping it back via `lo0`. `handle_tun_packet` saw the `fd::/8` prefix and pushed the packet onto the mesh outbound path, where it was dropped for lack of a session/route to ourselves (`drop_no_route`).

## Fix

When an outbound TUN packet's destination equals our own mesh address, hairpin it straight back to the TUN writer for local (inbound) delivery instead of routing it into the mesh.

The check is **unconditional**, not `#[cfg(macos)]`:
- On Linux the kernel already loops self-traffic via `lo` before it reaches the TUN, so the branch simply never fires there — but keeping it unconditional treats self-delivery as a daemon-level invariant (robust against rp_filter/netns/address-assignment quirks) rather than a bet on kernel routing.
- Unit tests run on Linux only in CI; gating to macOS would ship the fix permanently unverified by automation.

## Testing

- New unit tests: `self_addressed_packet_is_hairpinned_to_tun` and `other_fips_packet_goes_to_mesh`.
- Manually verified on macOS: with a patched daemon, `ping6` and an HTTP fetch to our own mesh address (and `<npub>.fips`) now succeed where they previously timed out.
- `cargo fmt --check`, `cargo clippy`, and `cargo test` clean.