### PR TITLE
packaging(openwrt): publish checksums-openwrt.txt + bump Node 20 actions

### DIFF
--- a/.github/workflows/package-openwrt.yml
+++ b/.github/workflows/package-openwrt.yml
@@ -26,7 +26,7 @@ jobs:
       package_version: ${{ steps.version.outputs.package_version }}
       release_channel: ${{ steps.channel.outputs.release_channel }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -96,7 +96,7 @@ jobs:
             # x86 routers / VMs
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -124,7 +124,7 @@ jobs:
 
       - name: Cache Cargo registry + build
         if: ${{ env.ACT != 'true' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -395,7 +395,7 @@ jobs:
 
       - name: Upload artifact (GitHub only)
         if: ${{ env.ACT != 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PACKAGE_FILENAME }}
           path: dist/${{ env.PACKAGE_FILENAME }}
@@ -519,7 +519,7 @@ jobs:
 
     steps:
       - name: Download all .ipk artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/package-openwrt.yml
+++ b/.github/workflows/package-openwrt.yml
@@ -524,8 +524,18 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Generate OpenWrt release checksums
+        run: |
+          cd dist
+          find . -maxdepth 1 -type f -name '*.ipk' -printf '%P\n' \
+            | LC_ALL=C sort \
+            | xargs sha256sum \
+            > checksums-openwrt.txt
+
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/*.ipk
+          files: |
+            dist/*.ipk
+            dist/checksums-openwrt.txt
           generate_release_notes: true


### PR DESCRIPTION
Two changes to `.github/workflows/package-openwrt.yml`:

1. **Publish `checksums-openwrt.txt` alongside the `.ipk` artifacts.** On tag pushes the release job downloads every per-arch `.ipk` artifact, generates a sorted `sha256sum` manifest, and attaches it to the GitHub Release next to the packages.

2. **Bump Node 20 actions to Node 24 majors** to clear the GitHub runner deprecation: `checkout@v4→v6`, `cache@v4→v5`, `upload-artifact@v4→v7`, `download-artifact@v4→v8`. Same upgrade as the repo-wide `chore/upgrade-node-actions` branch, scoped to this one file.

CI green: build matrix + `.ipk` artifact upload pass. The release/checksums job (and thus `download-artifact@v8`) runs on tag pushes.