### PR TITLE
feat(mobile): gate ethernet + system-tun behind default-on features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,16 @@ readme = "README.md"
 keywords = ["mesh", "p2p", "decentralized", "overlay-network", "nostr"]
 categories = ["network-programming", "command-line-utilities", "cryptography"]
 
+[features]
+# Desktop transports/seams, on by default. Mobile builds (Android/iOS)
+# use `default-features = false` to drop them.
+default = ["ethernet", "system-tun"]
+# Raw-socket Ethernet transport (Linux AF_PACKET / macOS BPF). Unavailable on mobile.
+ethernet = []
+# Manage a real system TUN device. When off, the TUN is app-owned (provided
+# by the embedder, e.g. Android VpnService); FIPS does no system-TUN ops.
+system-tun = []
+
 [dependencies]
 ratatui = "0.30"
 secp256k1 = { version = "0.30", features = ["rand", "global-context"] }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -48,7 +48,7 @@ use crate::bloom::{BloomFilter, BloomState};
 use crate::cache::CoordCache;
 use crate::node::session::SessionEntry;
 use crate::peer::{ActivePeer, PeerConnection};
-#[cfg(unix)]
+#[cfg(all(unix, feature = "ethernet"))]
 use crate::transport::ethernet::EthernetTransport;
 use crate::transport::nym::NymTransport;
 use crate::transport::tcp::TcpTransport;
@@ -928,7 +928,7 @@ impl Node {
         }
 
         // Create Ethernet transport instances (Unix only — requires raw sockets)
-        #[cfg(unix)]
+        #[cfg(all(unix, feature = "ethernet"))]
         {
             let eth_instances: Vec<_> = self
                 .config()
@@ -1062,7 +1062,7 @@ impl Node {
         &self,
         addr_str: &str,
     ) -> Result<(TransportId, TransportAddr), NodeError> {
-        #[cfg(unix)]
+        #[cfg(all(unix, feature = "ethernet"))]
         {
             let (iface, mac_str) = addr_str.split_once('/').ok_or_else(|| {
                 NodeError::NoTransportForType(format!(
@@ -1094,7 +1094,7 @@ impl Node {
 
             Ok((transport_id, TransportAddr::from_bytes(&mac)))
         }
-        #[cfg(not(unix))]
+        #[cfg(not(all(unix, feature = "ethernet")))]
         {
             Err(NodeError::NoTransportForType(
                 "Ethernet transport is not supported on this platform".to_string(),

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -11,7 +11,7 @@ pub mod tcp;
 pub mod tor;
 pub mod udp;
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "ethernet"))]
 pub mod ethernet;
 
 #[cfg(target_os = "linux")]
@@ -19,7 +19,7 @@ pub mod ble;
 
 #[cfg(target_os = "linux")]
 use ble::DefaultBleTransport;
-#[cfg(unix)]
+#[cfg(all(unix, feature = "ethernet"))]
 use ethernet::EthernetTransport;
 #[cfg(test)]
 use loopback::LoopbackTransport;
@@ -894,7 +894,7 @@ pub enum TransportHandle {
     /// UDP/IP transport.
     Udp(UdpTransport),
     /// Raw Ethernet transport.
-    #[cfg(unix)]
+    #[cfg(all(unix, feature = "ethernet"))]
     Ethernet(EthernetTransport),
     /// TCP/IP transport.
     Tcp(TcpTransport),
@@ -915,7 +915,7 @@ impl TransportHandle {
     pub async fn start(&mut self) -> Result<(), TransportError> {
         match self {
             TransportHandle::Udp(t) => t.start_async().await,
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(t) => t.start_async().await,
             TransportHandle::Tcp(t) => t.start_async().await,
             TransportHandle::Tor(t) => t.start_async().await,
@@ -931,7 +931,7 @@ impl TransportHandle {
     pub async fn stop(&mut self) -> Result<(), TransportError> {
         match self {
             TransportHandle::Udp(t) => t.stop_async().await,
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(t) => t.stop_async().await,
             TransportHandle::Tcp(t) => t.stop_async().await,
             TransportHandle::Tor(t) => t.stop_async().await,
@@ -947,7 +947,7 @@ impl TransportHandle {
     pub async fn send(&self, addr: &TransportAddr, data: &[u8]) -> Result<usize, TransportError> {
         match self {
             TransportHandle::Udp(t) => t.send_async(addr, data).await,
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(t) => t.send_async(addr, data).await,
             TransportHandle::Tcp(t) => t.send_async(addr, data).await,
             TransportHandle::Tor(t) => t.send_async(addr, data).await,
@@ -963,7 +963,7 @@ impl TransportHandle {
     pub fn transport_id(&self) -> TransportId {
         match self {
             TransportHandle::Udp(t) => t.transport_id(),
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(t) => t.transport_id(),
             TransportHandle::Tcp(t) => t.transport_id(),
             TransportHandle::Tor(t) => t.transport_id(),
@@ -979,7 +979,7 @@ impl TransportHandle {
     pub fn name(&self) -> Option<&str> {
         match self {
             TransportHandle::Udp(t) => t.name(),
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(t) => t.name(),
             TransportHandle::Tcp(t) => t.name(),
             TransportHandle::Tor(t) => t.name(),
@@ -995,7 +995,7 @@ impl TransportHandle {
     pub fn transport_type(&self) -> &TransportType {
         match self {
             TransportHandle::Udp(t) => t.transport_type(),
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(t) => t.transport_type(),
             TransportHandle::Tcp(t) => t.transport_type(),
             TransportHandle::Tor(t) => t.transport_type(),
@@ -1011,7 +1011,7 @@ impl TransportHandle {
     pub fn state(&self) -> TransportState {
         match self {
             TransportHandle::Udp(t) => t.state(),
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(t) => t.state(),
             TransportHandle::Tcp(t) => t.state(),
             TransportHandle::Tor(t) => t.state(),
@@ -1027,7 +1027,7 @@ impl TransportHandle {
     pub fn mtu(&self) -> u16 {
         match self {
             TransportHandle::Udp(t) => t.mtu(),
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(t) => t.mtu(),
             TransportHandle::Tcp(t) => t.mtu(),
             TransportHandle::Tor(t) => t.mtu(),
@@ -1046,7 +1046,7 @@ impl TransportHandle {
     pub fn link_mtu(&self, addr: &TransportAddr) -> u16 {
         match self {
             TransportHandle::Udp(t) => t.link_mtu(addr),
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(t) => t.link_mtu(addr),
             TransportHandle::Tcp(t) => t.link_mtu(addr),
             TransportHandle::Tor(t) => t.link_mtu(addr),
@@ -1062,7 +1062,7 @@ impl TransportHandle {
     pub fn local_addr(&self) -> Option<std::net::SocketAddr> {
         match self {
             TransportHandle::Udp(t) => t.local_addr(),
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(_) => None,
             TransportHandle::Tcp(t) => t.local_addr(),
             TransportHandle::Tor(_) => None,
@@ -1078,7 +1078,7 @@ impl TransportHandle {
     pub fn interface_name(&self) -> Option<&str> {
         match self {
             TransportHandle::Udp(_) => None,
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(t) => Some(t.interface_name()),
             TransportHandle::Tcp(_) => None,
             TransportHandle::Tor(_) => None,
@@ -1118,7 +1118,7 @@ impl TransportHandle {
     pub fn discover(&self) -> Result<Vec<DiscoveredPeer>, TransportError> {
         match self {
             TransportHandle::Udp(t) => t.discover(),
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(t) => t.discover(),
             TransportHandle::Tcp(t) => t.discover(),
             TransportHandle::Tor(t) => t.discover(),
@@ -1134,7 +1134,7 @@ impl TransportHandle {
     pub fn auto_connect(&self) -> bool {
         match self {
             TransportHandle::Udp(t) => t.auto_connect(),
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(t) => t.auto_connect(),
             TransportHandle::Tcp(t) => t.auto_connect(),
             TransportHandle::Tor(t) => t.auto_connect(),
@@ -1150,7 +1150,7 @@ impl TransportHandle {
     pub fn accept_connections(&self) -> bool {
         match self {
             TransportHandle::Udp(t) => t.accept_connections(),
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(t) => t.accept_connections(),
             TransportHandle::Tcp(t) => t.accept_connections(),
             TransportHandle::Tor(t) => t.accept_connections(),
@@ -1172,7 +1172,7 @@ impl TransportHandle {
     pub async fn connect(&self, addr: &TransportAddr) -> Result<(), TransportError> {
         match self {
             TransportHandle::Udp(_) => Ok(()), // connectionless
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(_) => Ok(()), // connectionless
             TransportHandle::Tcp(t) => t.connect_async(addr).await,
             TransportHandle::Tor(t) => t.connect_async(addr).await,
@@ -1192,7 +1192,7 @@ impl TransportHandle {
     pub fn connection_state(&self, addr: &TransportAddr) -> ConnectionState {
         match self {
             TransportHandle::Udp(_) => ConnectionState::Connected,
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(_) => ConnectionState::Connected,
             TransportHandle::Tcp(t) => t.connection_state_sync(addr),
             TransportHandle::Tor(t) => t.connection_state_sync(addr),
@@ -1211,7 +1211,7 @@ impl TransportHandle {
     pub async fn close_connection(&self, addr: &TransportAddr) {
         match self {
             TransportHandle::Udp(t) => t.close_connection(addr),
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(t) => t.close_connection(addr),
             TransportHandle::Tcp(t) => t.close_connection_async(addr).await,
             TransportHandle::Tor(t) => t.close_connection_async(addr).await,
@@ -1236,7 +1236,7 @@ impl TransportHandle {
     pub fn congestion(&self) -> TransportCongestion {
         match self {
             TransportHandle::Udp(t) => t.congestion(),
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(_) => TransportCongestion::default(),
             TransportHandle::Tcp(_) => TransportCongestion::default(),
             TransportHandle::Tor(_) => TransportCongestion::default(),
@@ -1256,7 +1256,7 @@ impl TransportHandle {
             TransportHandle::Udp(t) => {
                 serde_json::to_value(t.stats().snapshot()).unwrap_or_default()
             }
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ethernet"))]
             TransportHandle::Ethernet(t) => {
                 let snap = t.stats().snapshot();
                 serde_json::json!({

--- a/src/upper/dns.rs
+++ b/src/upper/dns.rs
@@ -301,7 +301,7 @@ fn extract_pktinfo_ifindex(msg: &libc::msghdr) -> Option<u32> {
         if cmsg.cmsg_level == libc::IPPROTO_IPV6 && cmsg.cmsg_type == libc::IPV6_PKTINFO {
             let data_ptr = unsafe { libc::CMSG_DATA(cmsg_ptr) } as *const libc::in6_pktinfo;
             let pktinfo: libc::in6_pktinfo = unsafe { std::ptr::read_unaligned(data_ptr) };
-            return Some(pktinfo.ipi6_ifindex);
+            return Some(pktinfo.ipi6_ifindex as u32);
         }
         cmsg_ptr = unsafe { libc::CMSG_NXTHDR(msg, cmsg_ptr) };
     }

--- a/src/upper/tun.rs
+++ b/src/upper/tun.rs
@@ -1224,7 +1224,33 @@ mod windows_tun {
 #[cfg(windows)]
 pub use windows_tun::{TunDevice, TunWriter, run_tun_reader, shutdown_tun_interface};
 
-#[cfg(target_os = "linux")]
+// Android uses an app-owned TUN (the VpnService owns the fd); FIPS never creates
+// or configures a system TUN here. These stubs let the unix TunDevice code
+// compile; they are not exercised when tun.enabled = false.
+#[cfg(all(unix, not(feature = "system-tun")))]
+mod platform {
+    use super::TunError;
+    use std::net::Ipv6Addr;
+
+    pub fn is_ipv6_disabled() -> bool {
+        false
+    }
+    pub async fn interface_exists(_name: &str) -> bool {
+        false
+    }
+    pub async fn delete_interface(_name: &str) -> Result<(), TunError> {
+        Ok(())
+    }
+    pub async fn configure_interface(
+        _name: &str,
+        _addr: Ipv6Addr,
+        _mtu: u16,
+    ) -> Result<(), TunError> {
+        Ok(())
+    }
+}
+
+#[cfg(all(target_os = "linux", feature = "system-tun"))]
 mod platform {
     use super::TunError;
     use futures::TryStreamExt;
@@ -1333,7 +1359,7 @@ mod platform {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "system-tun"))]
 mod platform {
     use super::TunError;
     use std::net::Ipv6Addr;


### PR DESCRIPTION
## What

Introduces two default-on Cargo features so the crate can cross-compile for
mobile (Android/iOS) via `default-features = false`, while leaving desktop
builds completely unchanged.

- **`ethernet`** — gates the raw-socket Ethernet transport (Linux AF_PACKET /
  macOS BPF): the module, the `TransportHandle::Ethernet` variant and all its
  match arms, node construction, and `resolve_ethernet_addr`.
- **`system-tun`** — gates the real TUN platform ops. When off, a no-op
  platform stub stands in and the TUN is app-owned by the embedder (e.g. an
  Android `VpnService`); FIPS performs no system-TUN operations.
- **dns** — `ipi6_ifindex` is `i32` on Android vs `u32` on macOS; added a cast.

`default = [ethernet, system-tun]`, so desktop builds pull both in exactly as
before.

## Why

This is the foundation for the mobile/BLE work. Splitting it out keeps the
plumbing — which is behavior-preserving and mostly mechanical `#[cfg]`
gating — reviewable on its own, and shrinks the follow-up BLE PR to just the
BLE-specific logic.

## Risk / behavior change

None for existing users: both features are on by default, so every desktop
and server build is identical to before. The change is almost entirely
repetitive `#[cfg(unix)]` → `#[cfg(all(unix, feature = "ethernet"))]` edits
across the `TransportHandle` match arms.

## Note for reviewers

The `system-tun`-off path (the no-op TUN stub) has no in-tree consumer yet —
its first user is the app-owned TUN seam that lands in the follow-up `ble-v2`
stack (embedder provides the fd, FIPS talks to it over channels). This PR is
the prerequisite plumbing; the off path is exercised by the mobile embedder.

## Test plan

- [ ] `cargo build` (default features) — desktop unchanged
- [ ] `cargo build --no-default-features` — confirms the mobile gating compiles
- [ ] `cargo clippy` / `cargo fmt --check`