### PR TITLE
feat(mobile): gate desktop transports/TUN by target_os, not features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,50 @@ jobs:
           retention-days: 1
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Job 1b – Android cross-build (NDK)
+#
+# Verifies the target_os cfg gating compiles for Android. FIPS runs on Android
+# as an embedded library (the host app owns the TUN via a VpnService), so this
+# builds the library only — the desktop daemon binaries are not built there.
+# cargo-ndk wires up the NDK clang/linker the C dependencies (e.g. secp256k1-sys)
+# need; the runner image ships the NDK.
+# ─────────────────────────────────────────────────────────────────────────────
+  build-android:
+    name: Build (Android NDK)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set SOURCE_DATE_EPOCH from git
+        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> "$GITHUB_ENV"
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+          rustflags: ''
+          target: aarch64-linux-android
+
+      - name: Cache Cargo registry + build
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: android-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            android-cargo-
+
+      - name: Install cargo-ndk
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-ndk
+
+      - name: Build library (Android arm64)
+        run: cargo ndk -t arm64-v8a build --lib
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Job 2 – Unit tests
 #
 # Runs `cargo test` on Linux.  Gated on the build matrix completing so we

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -41,14 +41,18 @@ use self::routing_error_rate_limit::RoutingErrorRateLimiter;
 /// `node.rekey.after_secs` remains the nominal interval (mean preserved).
 pub(crate) const REKEY_JITTER_SECS: i64 = 15;
 use self::wire::{
-    ESTABLISHED_HEADER_SIZE, FLAG_CE, FLAG_KEY_EPOCH, FLAG_SP, build_encrypted,
-    build_established_header, prepend_inner_header,
+    FLAG_CE, FLAG_KEY_EPOCH, FLAG_SP, build_encrypted, build_established_header,
+    prepend_inner_header,
 };
+// Only referenced by the unix UDP fast-path block below; on Windows the wire
+// buffer is sized through build_encrypted, leaving this import otherwise unused.
+#[cfg(unix)]
+use self::wire::ESTABLISHED_HEADER_SIZE;
 use crate::bloom::{BloomFilter, BloomState};
 use crate::cache::CoordCache;
 use crate::node::session::SessionEntry;
 use crate::peer::{ActivePeer, PeerConnection};
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use crate::transport::ethernet::EthernetTransport;
 use crate::transport::nym::NymTransport;
 use crate::transport::tcp::TcpTransport;
@@ -928,7 +932,7 @@ impl Node {
         }
 
         // Create Ethernet transport instances (Unix only — requires raw sockets)
-        #[cfg(unix)]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         {
             let eth_instances: Vec<_> = self
                 .config()
@@ -1062,7 +1066,7 @@ impl Node {
         &self,
         addr_str: &str,
     ) -> Result<(TransportId, TransportAddr), NodeError> {
-        #[cfg(unix)]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         {
             let (iface, mac_str) = addr_str.split_once('/').ok_or_else(|| {
                 NodeError::NoTransportForType(format!(
@@ -1094,7 +1098,7 @@ impl Node {
 
             Ok((transport_id, TransportAddr::from_bytes(&mac)))
         }
-        #[cfg(not(unix))]
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         {
             Err(NodeError::NoTransportForType(
                 "Ethernet transport is not supported on this platform".to_string(),

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -11,7 +11,7 @@ pub mod tcp;
 pub mod tor;
 pub mod udp;
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub mod ethernet;
 
 #[cfg(target_os = "linux")]
@@ -19,7 +19,7 @@ pub mod ble;
 
 #[cfg(target_os = "linux")]
 use ble::DefaultBleTransport;
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use ethernet::EthernetTransport;
 #[cfg(test)]
 use loopback::LoopbackTransport;
@@ -894,7 +894,7 @@ pub enum TransportHandle {
     /// UDP/IP transport.
     Udp(UdpTransport),
     /// Raw Ethernet transport.
-    #[cfg(unix)]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     Ethernet(EthernetTransport),
     /// TCP/IP transport.
     Tcp(TcpTransport),
@@ -915,7 +915,7 @@ impl TransportHandle {
     pub async fn start(&mut self) -> Result<(), TransportError> {
         match self {
             TransportHandle::Udp(t) => t.start_async().await,
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(t) => t.start_async().await,
             TransportHandle::Tcp(t) => t.start_async().await,
             TransportHandle::Tor(t) => t.start_async().await,
@@ -931,7 +931,7 @@ impl TransportHandle {
     pub async fn stop(&mut self) -> Result<(), TransportError> {
         match self {
             TransportHandle::Udp(t) => t.stop_async().await,
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(t) => t.stop_async().await,
             TransportHandle::Tcp(t) => t.stop_async().await,
             TransportHandle::Tor(t) => t.stop_async().await,
@@ -947,7 +947,7 @@ impl TransportHandle {
     pub async fn send(&self, addr: &TransportAddr, data: &[u8]) -> Result<usize, TransportError> {
         match self {
             TransportHandle::Udp(t) => t.send_async(addr, data).await,
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(t) => t.send_async(addr, data).await,
             TransportHandle::Tcp(t) => t.send_async(addr, data).await,
             TransportHandle::Tor(t) => t.send_async(addr, data).await,
@@ -963,7 +963,7 @@ impl TransportHandle {
     pub fn transport_id(&self) -> TransportId {
         match self {
             TransportHandle::Udp(t) => t.transport_id(),
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(t) => t.transport_id(),
             TransportHandle::Tcp(t) => t.transport_id(),
             TransportHandle::Tor(t) => t.transport_id(),
@@ -979,7 +979,7 @@ impl TransportHandle {
     pub fn name(&self) -> Option<&str> {
         match self {
             TransportHandle::Udp(t) => t.name(),
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(t) => t.name(),
             TransportHandle::Tcp(t) => t.name(),
             TransportHandle::Tor(t) => t.name(),
@@ -995,7 +995,7 @@ impl TransportHandle {
     pub fn transport_type(&self) -> &TransportType {
         match self {
             TransportHandle::Udp(t) => t.transport_type(),
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(t) => t.transport_type(),
             TransportHandle::Tcp(t) => t.transport_type(),
             TransportHandle::Tor(t) => t.transport_type(),
@@ -1011,7 +1011,7 @@ impl TransportHandle {
     pub fn state(&self) -> TransportState {
         match self {
             TransportHandle::Udp(t) => t.state(),
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(t) => t.state(),
             TransportHandle::Tcp(t) => t.state(),
             TransportHandle::Tor(t) => t.state(),
@@ -1027,7 +1027,7 @@ impl TransportHandle {
     pub fn mtu(&self) -> u16 {
         match self {
             TransportHandle::Udp(t) => t.mtu(),
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(t) => t.mtu(),
             TransportHandle::Tcp(t) => t.mtu(),
             TransportHandle::Tor(t) => t.mtu(),
@@ -1046,7 +1046,7 @@ impl TransportHandle {
     pub fn link_mtu(&self, addr: &TransportAddr) -> u16 {
         match self {
             TransportHandle::Udp(t) => t.link_mtu(addr),
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(t) => t.link_mtu(addr),
             TransportHandle::Tcp(t) => t.link_mtu(addr),
             TransportHandle::Tor(t) => t.link_mtu(addr),
@@ -1062,7 +1062,7 @@ impl TransportHandle {
     pub fn local_addr(&self) -> Option<std::net::SocketAddr> {
         match self {
             TransportHandle::Udp(t) => t.local_addr(),
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(_) => None,
             TransportHandle::Tcp(t) => t.local_addr(),
             TransportHandle::Tor(_) => None,
@@ -1078,7 +1078,7 @@ impl TransportHandle {
     pub fn interface_name(&self) -> Option<&str> {
         match self {
             TransportHandle::Udp(_) => None,
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(t) => Some(t.interface_name()),
             TransportHandle::Tcp(_) => None,
             TransportHandle::Tor(_) => None,
@@ -1118,7 +1118,7 @@ impl TransportHandle {
     pub fn discover(&self) -> Result<Vec<DiscoveredPeer>, TransportError> {
         match self {
             TransportHandle::Udp(t) => t.discover(),
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(t) => t.discover(),
             TransportHandle::Tcp(t) => t.discover(),
             TransportHandle::Tor(t) => t.discover(),
@@ -1134,7 +1134,7 @@ impl TransportHandle {
     pub fn auto_connect(&self) -> bool {
         match self {
             TransportHandle::Udp(t) => t.auto_connect(),
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(t) => t.auto_connect(),
             TransportHandle::Tcp(t) => t.auto_connect(),
             TransportHandle::Tor(t) => t.auto_connect(),
@@ -1150,7 +1150,7 @@ impl TransportHandle {
     pub fn accept_connections(&self) -> bool {
         match self {
             TransportHandle::Udp(t) => t.accept_connections(),
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(t) => t.accept_connections(),
             TransportHandle::Tcp(t) => t.accept_connections(),
             TransportHandle::Tor(t) => t.accept_connections(),
@@ -1172,7 +1172,7 @@ impl TransportHandle {
     pub async fn connect(&self, addr: &TransportAddr) -> Result<(), TransportError> {
         match self {
             TransportHandle::Udp(_) => Ok(()), // connectionless
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(_) => Ok(()), // connectionless
             TransportHandle::Tcp(t) => t.connect_async(addr).await,
             TransportHandle::Tor(t) => t.connect_async(addr).await,
@@ -1192,7 +1192,7 @@ impl TransportHandle {
     pub fn connection_state(&self, addr: &TransportAddr) -> ConnectionState {
         match self {
             TransportHandle::Udp(_) => ConnectionState::Connected,
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(_) => ConnectionState::Connected,
             TransportHandle::Tcp(t) => t.connection_state_sync(addr),
             TransportHandle::Tor(t) => t.connection_state_sync(addr),
@@ -1211,7 +1211,7 @@ impl TransportHandle {
     pub async fn close_connection(&self, addr: &TransportAddr) {
         match self {
             TransportHandle::Udp(t) => t.close_connection(addr),
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(t) => t.close_connection(addr),
             TransportHandle::Tcp(t) => t.close_connection_async(addr).await,
             TransportHandle::Tor(t) => t.close_connection_async(addr).await,
@@ -1236,7 +1236,7 @@ impl TransportHandle {
     pub fn congestion(&self) -> TransportCongestion {
         match self {
             TransportHandle::Udp(t) => t.congestion(),
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(_) => TransportCongestion::default(),
             TransportHandle::Tcp(_) => TransportCongestion::default(),
             TransportHandle::Tor(_) => TransportCongestion::default(),
@@ -1256,7 +1256,7 @@ impl TransportHandle {
             TransportHandle::Udp(t) => {
                 serde_json::to_value(t.stats().snapshot()).unwrap_or_default()
             }
-            #[cfg(unix)]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             TransportHandle::Ethernet(t) => {
                 let snap = t.stats().snapshot();
                 serde_json::json!({

--- a/src/upper/dns.rs
+++ b/src/upper/dns.rs
@@ -301,7 +301,7 @@ fn extract_pktinfo_ifindex(msg: &libc::msghdr) -> Option<u32> {
         if cmsg.cmsg_level == libc::IPPROTO_IPV6 && cmsg.cmsg_type == libc::IPV6_PKTINFO {
             let data_ptr = unsafe { libc::CMSG_DATA(cmsg_ptr) } as *const libc::in6_pktinfo;
             let pktinfo: libc::in6_pktinfo = unsafe { std::ptr::read_unaligned(data_ptr) };
-            return Some(pktinfo.ipi6_ifindex);
+            return Some(pktinfo.ipi6_ifindex as u32);
         }
         cmsg_ptr = unsafe { libc::CMSG_NXTHDR(msg, cmsg_ptr) };
     }

--- a/src/upper/tun.rs
+++ b/src/upper/tun.rs
@@ -1224,6 +1224,32 @@ mod windows_tun {
 #[cfg(windows)]
 pub use windows_tun::{TunDevice, TunWriter, run_tun_reader, shutdown_tun_interface};
 
+// Android uses an app-owned TUN (the embedder owns the fd, e.g. an Android
+// VpnService); FIPS never creates or configures a system TUN here. These no-op
+// stubs stand in for the platform ops so the shared TunDevice code compiles.
+#[cfg(target_os = "android")]
+mod platform {
+    use super::TunError;
+    use std::net::Ipv6Addr;
+
+    pub fn is_ipv6_disabled() -> bool {
+        false
+    }
+    pub async fn interface_exists(_name: &str) -> bool {
+        false
+    }
+    pub async fn delete_interface(_name: &str) -> Result<(), TunError> {
+        Ok(())
+    }
+    pub async fn configure_interface(
+        _name: &str,
+        _addr: Ipv6Addr,
+        _mtu: u16,
+    ) -> Result<(), TunError> {
+        Ok(())
+    }
+}
+
 #[cfg(target_os = "linux")]
 mod platform {
     use super::TunError;


### PR DESCRIPTION
## What

Makes a plain, flagless `cargo build` compile correctly for every target: the
compiler selects platform code by `target_os`, enabling what each platform
supports and disabling what it doesn't. Android no longer needs
`--no-default-features` (no Cargo features are introduced at all).

The core issue this fixes: Android is `target_os = "android"` but also satisfies
`cfg(unix)`, so the old `#[cfg(unix)]` gates dragged desktop-only code (raw
AF_PACKET sockets, system-TUN ops) onto Android. Keying off `target_os` lets
each platform self-select, exactly like Windows already does.

- **ethernet** — gated `any(target_os = "linux", target_os = "macos")` (raw
  AF_PACKET / macOS BPF). `target_os = "linux"` is false on Android, so the
  raw-socket transport self-excludes there.
- **system-tun** — real platform ops gated per `target_os = "linux"`/`"macos"`;
  Windows keeps its own path. Android gets a no-op stub — the TUN is app-owned
  by the embedder (e.g. an Android `VpnService`); FIPS does no system-TUN ops.
- **dns** — `ipi6_ifindex` is `i32` on Android vs `u32` on macOS; added a cast.
- **node** — gate the unix-only `ESTABLISHED_HEADER_SIZE` import so the Windows
  build is warning-clean.

## Why this shape

`any(target_os = "linux", target_os = "macos")` is already the codebase's idiom
(60+ existing uses); both the positive and negated forms here match existing
convention. The only new combo is the Android TUN stub. iOS is intentionally
out of scope for now.

## Risk

None for existing users: desktop/server builds are byte-for-byte the same set of
code paths — this is mechanical `#[cfg]` retargeting, no behavior change.

## Note for reviewers

The Android-only path (no-op TUN stub) has no in-tree consumer yet; its first
user is the app-owned TUN seam in the follow-up BLE/Android PR. This is the
prerequisite build plumbing.

## Test plan

- [ ] `cargo build` (host) — desktop unchanged
- [ ] `cargo clippy` / `cargo fmt --check`
- [ ] Android cross-build compiles the gates (needs NDK toolchain)