### PR TITLE
packaging(openwrt): default .apk WAN port to DSA name 'wan'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- openwrt: the `.apk` package now defaults `ethernet.wan` to the
+  OpenWrt 25 DSA port name `wan`; the `.ipk` package keeps `eth0` for
+  OpenWrt 24 and earlier.
+
 ### Fixed
 
 ## [0.4.0] - 2026-06-21

--- a/packaging/openwrt-apk/build-apk.sh
+++ b/packaging/openwrt-apk/build-apk.sh
@@ -191,6 +191,13 @@ install -d "$STAGE_DIR/etc/fips"
 install -m 0600 "$FILES_DIR/etc/fips/fips.yaml"   "$STAGE_DIR/etc/fips/fips.yaml"
 install -m 0755 "$FILES_DIR/etc/fips/firewall.sh" "$STAGE_DIR/etc/fips/firewall.sh"
 
+# The shared fips.yaml ships ethernet.wan.interface: "eth0", the OpenWrt 24
+# default. This .apk package targets OpenWrt 25+ (DSA), where the WAN port is
+# named "wan", so ship "wan" as the default. Patching the staged copy keeps the
+# as-installed config correct for the platform without maintaining a second copy
+# of the file; operators can still edit /etc/fips/fips.yaml for non-standard boards.
+sed -i 's|interface: "eth0"|interface: "wan"|' "$STAGE_DIR/etc/fips/fips.yaml"
+
 install -d "$STAGE_DIR/etc/dnsmasq.d"
 install -m 0644 "$FILES_DIR/etc/dnsmasq.d/fips.conf" "$STAGE_DIR/etc/dnsmasq.d/fips.conf"
 

--- a/packaging/openwrt-ipk/README.md
+++ b/packaging/openwrt-ipk/README.md
@@ -132,7 +132,10 @@ The default config enables:
 
 For Ethernet transport, uncomment the `ethernet:` section and set the correct
 physical interface names for your router. **Always use physical port names
-(`eth0`, `eth1`), never bridge names (`br-lan`).** See
+(`eth0`, `eth1`, or DSA port names like `wan`/`lan1`), never bridge names
+(`br-lan`).** The shipped default WAN port is `eth0` (OpenWrt 24); on OpenWrt
+25 (DSA) boards the WAN port is named `wan` — the `.apk` package ships that
+default. Run `ip link show` to confirm the names on your board. See
 [`deploy/native/README.md`](../../deploy/native/README.md) for details.
 
 ## Service management


### PR DESCRIPTION
The shared fips.yaml ships ethernet.wan.interface: "eth0", the default WAN port on OpenWrt 24 and earlier. OpenWrt 25 (DSA) boards, which the .apk package targets, name the WAN port "wan" instead. Rewrite the staged copy at build time so the as-installed config binds the Ethernet transport to the right port out of the box, without maintaining a second copy of the config file. The .ipk package keeps "eth0".

Update the openwrt README to document eth0 (24) vs wan (25/DSA) and add a CHANGELOG entry.