### PR TITLE
Enable Android fips and fipsctl builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1", features = ["rt", "macros", "signal", "sync", "net", "time", "process", "io-util"] }
 futures = "0.3"
 simple-dns = "0.11.2"
-mdns-sd = "0.19"
 socket2 = { version = "0.6.2", features = ["all"] }
 tokio-socks = "0.5"
 portable-atomic = { version = "1", features = ["std"] }
@@ -44,6 +43,9 @@ arc-swap = "1"
 [target.'cfg(unix)'.dependencies]
 tun = { version = "0.8.7", features = ["async"] }
 libc = "0.2"
+
+[target.'cfg(not(target_os = "android"))'.dependencies]
+mdns-sd = "0.19"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = "0.21.0"

--- a/src/discovery/lan/mod.rs
+++ b/src/discovery/lan/mod.rs
@@ -25,14 +25,20 @@
 //! matching scope. Nodes on the same physical LAN but configured for
 //! different mesh networks don't cross-feed each other.
 
+#[cfg(not(target_os = "android"))]
 use std::collections::HashMap;
-use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::net::SocketAddr;
+#[cfg(not(target_os = "android"))]
+use std::net::{SocketAddrV4, SocketAddrV6};
 use std::sync::Arc;
 use std::time::Instant;
 
+#[cfg(not(target_os = "android"))]
 use mdns_sd::{ScopedIp, ServiceDaemon, ServiceEvent, ServiceInfo};
 use thiserror::Error;
+#[cfg(not(target_os = "android"))]
 use tokio::sync::Mutex;
+#[cfg(not(target_os = "android"))]
 use tracing::{debug, info, warn};
 
 use crate::Identity;
@@ -129,6 +135,7 @@ impl LanDiscoveryConfig {
 }
 
 /// Running mDNS responder + browser bound to the node's UDP advert port.
+#[cfg(not(target_os = "android"))]
 pub struct LanDiscovery {
     daemon: ServiceDaemon,
     own_npub: String,
@@ -137,6 +144,12 @@ pub struct LanDiscovery {
     event_pump: tokio::task::JoinHandle<()>,
 }
 
+#[cfg(target_os = "android")]
+pub struct LanDiscovery {
+    own_npub: String,
+}
+
+#[cfg(not(target_os = "android"))]
 impl LanDiscovery {
     /// Start the mDNS responder and browser.
     ///
@@ -340,11 +353,44 @@ impl LanDiscovery {
     }
 }
 
+#[cfg(target_os = "android")]
+impl LanDiscovery {
+    pub async fn start(
+        identity: &Identity,
+        _scope: Option<String>,
+        advertised_port: u16,
+        config: LanDiscoveryConfig,
+    ) -> Result<Arc<Self>, LanDiscoveryError> {
+        if !config.enabled {
+            return Err(LanDiscoveryError::Disabled);
+        }
+        if advertised_port == 0 {
+            return Err(LanDiscoveryError::NoAdvertisedPort);
+        }
+        let _ = identity;
+        Err(LanDiscoveryError::Daemon(
+            "LAN discovery is not supported on Android".into(),
+        ))
+    }
+
+    pub fn own_npub(&self) -> &str {
+        &self.own_npub
+    }
+
+    pub async fn drain_events(&self) -> Vec<LanEvent> {
+        Vec::new()
+    }
+
+    pub async fn shutdown(self: &Arc<Self>) {}
+}
+
+#[cfg(not(target_os = "android"))]
 fn short(npub: &str) -> &str {
     let end = 16.min(npub.len());
     &npub[..end]
 }
 
+#[cfg(not(target_os = "android"))]
 fn socket_addr_from_scoped_ip(scoped: &ScopedIp, port: u16) -> Option<SocketAddr> {
     match scoped {
         ScopedIp::V4(v4) => Some(SocketAddr::V4(SocketAddrV4::new(*v4.addr(), port))),
@@ -360,6 +406,7 @@ fn socket_addr_from_scoped_ip(scoped: &ScopedIp, port: u16) -> Option<SocketAddr
     }
 }
 
+#[cfg(not(target_os = "android"))]
 fn ipv6_is_unicast_link_local(ip: std::net::Ipv6Addr) -> bool {
     (ip.segments()[0] & 0xffc0) == 0xfe80
 }

--- a/src/discovery/nostr/stun.rs
+++ b/src/discovery/nostr/stun.rs
@@ -265,7 +265,7 @@ fn push_private_interface_ips(addresses: &mut Vec<String>) {
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "android")))]
 fn private_interface_ips() -> Vec<IpAddr> {
     let mut output = Vec::new();
     let mut ifaddrs: *mut libc::ifaddrs = std::ptr::null_mut();
@@ -319,11 +319,12 @@ fn private_interface_ips() -> Vec<IpAddr> {
     output
 }
 
-#[cfg(not(unix))]
+#[cfg(any(not(unix), target_os = "android"))]
 fn private_interface_ips() -> Vec<IpAddr> {
     Vec::new()
 }
 
+#[cfg(not(target_os = "android"))]
 fn is_private_overlay_candidate_ip(ip: IpAddr) -> bool {
     match ip {
         IpAddr::V4(v4) => v4.is_private(),

--- a/src/transport/ethernet/socket.rs
+++ b/src/transport/ethernet/socket.rs
@@ -18,6 +18,45 @@ mod platform;
 #[path = "socket_macos.rs"]
 mod platform;
 
+#[cfg(target_os = "android")]
+mod platform {
+    use crate::transport::TransportError;
+
+    pub struct PacketSocket;
+
+    impl PacketSocket {
+        pub fn open(_interface: &str, _ethertype: u16) -> Result<Self, TransportError> {
+            Err(TransportError::NotSupported(
+                "raw Ethernet sockets are not supported on Android".into(),
+            ))
+        }
+
+        pub fn local_mac(&self) -> Result<[u8; 6], TransportError> {
+            Err(TransportError::NotSupported(
+                "raw Ethernet sockets are not supported on Android".into(),
+            ))
+        }
+
+        pub fn interface_mtu(&self) -> Result<u16, TransportError> {
+            Err(TransportError::NotSupported(
+                "raw Ethernet sockets are not supported on Android".into(),
+            ))
+        }
+
+        pub fn set_recv_buffer_size(&self, _size: usize) -> Result<(), TransportError> {
+            Err(TransportError::NotSupported(
+                "raw Ethernet sockets are not supported on Android".into(),
+            ))
+        }
+
+        pub fn set_send_buffer_size(&self, _size: usize) -> Result<(), TransportError> {
+            Err(TransportError::NotSupported(
+                "raw Ethernet sockets are not supported on Android".into(),
+            ))
+        }
+    }
+}
+
 #[cfg(unix)]
 pub use platform::PacketSocket;
 
@@ -261,6 +300,44 @@ mod async_impl {
                 let _ = handle.join();
             }
         }
+    }
+}
+
+#[cfg(target_os = "android")]
+mod async_impl {
+    use super::PacketSocket;
+    use crate::transport::TransportError;
+
+    pub struct AsyncPacketSocket {
+        inner: PacketSocket,
+    }
+
+    impl AsyncPacketSocket {
+        pub fn new(socket: PacketSocket) -> Result<Self, TransportError> {
+            Ok(Self { inner: socket })
+        }
+
+        pub async fn send_to(
+            &self,
+            _data: &[u8],
+            _dest_mac: &[u8; 6],
+        ) -> Result<usize, TransportError> {
+            Err(TransportError::NotSupported(
+                "raw Ethernet sockets are not supported on Android".into(),
+            ))
+        }
+
+        pub async fn recv_from(&self, _buf: &mut [u8]) -> Result<(usize, [u8; 6]), TransportError> {
+            Err(TransportError::NotSupported(
+                "raw Ethernet sockets are not supported on Android".into(),
+            ))
+        }
+
+        pub fn get_ref(&self) -> &PacketSocket {
+            &self.inner
+        }
+
+        pub fn shutdown(&self) {}
     }
 }
 

--- a/src/upper/dns.rs
+++ b/src/upper/dns.rs
@@ -301,6 +301,9 @@ fn extract_pktinfo_ifindex(msg: &libc::msghdr) -> Option<u32> {
         if cmsg.cmsg_level == libc::IPPROTO_IPV6 && cmsg.cmsg_type == libc::IPV6_PKTINFO {
             let data_ptr = unsafe { libc::CMSG_DATA(cmsg_ptr) } as *const libc::in6_pktinfo;
             let pktinfo: libc::in6_pktinfo = unsafe { std::ptr::read_unaligned(data_ptr) };
+            #[cfg(target_os = "android")]
+            return u32::try_from(pktinfo.ipi6_ifindex).ok();
+            #[cfg(not(target_os = "android"))]
             return Some(pktinfo.ipi6_ifindex);
         }
         cmsg_ptr = unsafe { libc::CMSG_NXTHDR(msg, cmsg_ptr) };

--- a/src/upper/tun.rs
+++ b/src/upper/tun.rs
@@ -31,7 +31,7 @@ use tracing::error;
 use tracing::{debug, trace};
 #[cfg(windows)]
 use tracing::{error, warn};
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use tun::Layer;
 
 /// Read-only handle to the per-destination path MTU map. Populated by
@@ -235,6 +235,7 @@ impl TunDevice {
         }
 
         // Create the TUN device
+        #[cfg_attr(target_os = "android", allow(unused_mut))]
         let mut tun_config = tun::Configuration::default();
 
         // On macOS, utun devices get kernel-assigned names (utun0, utun1, ...),
@@ -1421,6 +1422,36 @@ mod platform {
             )));
         }
         Ok(())
+    }
+}
+
+#[cfg(target_os = "android")]
+mod platform {
+    use super::TunError;
+    use std::net::Ipv6Addr;
+
+    pub fn is_ipv6_disabled() -> bool {
+        false
+    }
+
+    pub async fn interface_exists(_name: &str) -> bool {
+        false
+    }
+
+    pub async fn delete_interface(name: &str) -> Result<(), TunError> {
+        Err(TunError::Configure(format!(
+            "TUN interface management is not supported on Android: {name}"
+        )))
+    }
+
+    pub async fn configure_interface(
+        name: &str,
+        _addr: Ipv6Addr,
+        _mtu: u16,
+    ) -> Result<(), TunError> {
+        Err(TunError::Configure(format!(
+            "TUN interface management is not supported on Android: {name}"
+        )))
     }
 }
 


### PR DESCRIPTION
## Summary
- make host-only mDNS, raw Ethernet, and TUN setup compile as explicit unsupported Android paths
- avoid Android getifaddrs linker failures by excluding mdns-sd on Android
- fix Android DNS pktinfo type conversion without tripping host Clippy so fips/fipsctl build for x86_64 Android

## Verification
- cargo fmt --check && git diff --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo build --target x86_64-linux-android --bin fips --bin fipsctl
- cargo build --release --target x86_64-linux-android --bin fips --bin fipsctl
- MeshDrop installed APK smoke used the release-built binaries and reported android-native-fipsctl with rustCore=true

## Known gaps
- ARM64 Android cross-build not run in this branch
- Android raw Ethernet, host TUN management, and LAN discovery remain intentionally unsupported