### PR TITLE
 fix: follow the macOS install layout for config, ACL, and identity paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keep `/etc/fips`, Windows is unchanged, and the values are pinned by
   platform-gated unit tests.
 
+- macOS: the system-wide config search path is now
+  `/usr/local/etc/fips/fips.yaml`, matching the install layout the macOS
+  packaging ships. It was hardcoded to `/etc/fips/fips.yaml`, so a bare
+  `fips` run without `--config` probed a directory that does not exist and
+  derived identity key paths from it. The search path and `fipsctl keygen`
+  now share one platform constant for the config dir, so the two cannot
+  drift apart again. The launchd-installed daemon was unaffected (it always
+  passes `--config`). Linux and Windows behavior is unchanged.
+
 - Nostr NAT traversal no longer breaks after the host suspends. The traversal
   clock cached a Unix timestamp once at startup and advanced it with a
   monotonic `Instant`, which does not tick while a machine is asleep, so after

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,11 +46,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returned an empty ACL / empty host map. A populated `peers.deny` therefore
   reported `effective_mode: "default_open"` and `enforcement_active: false`
   via `fipsctl acl show`, and host-file aliases went unloaded, with no error
-  or warning. The constants now follow the platform's packaging —
-  `/usr/local/etc/fips/` on macOS, `/etc/fips/` on Linux and other Unix,
-  `%ProgramData%\fips\` on Windows — and are pinned by platform-gated unit
-  tests so the layout cannot silently drift again. Linux and Windows
-  behavior is unchanged.
+  or warning. The default constants now follow the platform's packaging —
+  `/usr/local/etc/fips/` on macOS, `/etc/fips/` on Linux and other Unix
+  for the ACL files, and `/etc/fips/` on Linux and `%ProgramData%\fips\`
+  on Windows for the hosts file — and are pinned by platform-gated unit
+  tests so the layout cannot silently drift again. At startup the daemon
+  warns once if any of these files exist at the old `/etc/fips/` location
+  but not at the current default. Linux and Windows behavior is unchanged.
+  **macOS users with existing files in `/etc/fips/` should move them to
+  `/usr/local/etc/fips/`.**
 
 - macOS: `fipsctl keygen` now writes `fips.key` / `fips.pub` to
   `/usr/local/etc/fips/` by default, matching the install layout the macOS
@@ -62,14 +66,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keep `/etc/fips`, Windows is unchanged, and the values are pinned by
   platform-gated unit tests.
 
-- macOS: the system-wide config search path is now
-  `/usr/local/etc/fips/fips.yaml`, matching the install layout the macOS
-  packaging ships. It was hardcoded to `/etc/fips/fips.yaml`, so a bare
-  `fips` run without `--config` probed a directory that does not exist and
-  derived identity key paths from it. The search path and `fipsctl keygen`
-  now share one platform constant for the config dir, so the two cannot
-  drift apart again. The launchd-installed daemon was unaffected (it always
-  passes `--config`). Linux and Windows behavior is unchanged.
+- macOS: the system-wide config search path now includes
+  `/usr/local/etc/fips/fips.yaml` in addition to `/etc/fips/fips.yaml`,
+  matching the install layout the macOS packaging ships. Previously only
+  `/etc/fips/fips.yaml` was probed, so a bare `fips` run without `--config`
+  skipped the installed config and derived identity key paths from a
+  non-existent directory. `/etc/fips/fips.yaml` is still probed first so
+  existing installs keep working; `fipsctl keygen` writes to
+  `/usr/local/etc/fips/` via the shared `SYSTEM_CONFIG_DIR` constant, so
+  the two cannot drift apart. The launchd-installed daemon was unaffected
+  (it always passes `--config`). Linux and Windows behavior is unchanged.
 
 - Nostr NAT traversal no longer breaks after the host suspends. The traversal
   clock cached a Unix timestamp once at startup and advanced it with a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tests so the layout cannot silently drift again. Linux and Windows
   behavior is unchanged.
 
+- macOS: `fipsctl keygen` now writes `fips.key` / `fips.pub` to
+  `/usr/local/etc/fips/` by default, matching the install layout the macOS
+  packaging ships. The default output directory was hardcoded to
+  `/etc/fips` for all Unix, but the daemon derives its identity key paths
+  from the config file's directory — `/usr/local/etc/fips/fips.yaml` on
+  macOS — so a generated identity landed where the daemon never reads it
+  and the node silently kept an ephemeral identity. Linux and other Unix
+  keep `/etc/fips`, Windows is unchanged, and the values are pinned by
+  platform-gated unit tests.
+
 - Nostr NAT traversal no longer breaks after the host suspends. The traversal
   clock cached a Unix timestamp once at startup and advanced it with a
   monotonic `Instant`, which does not tick while a machine is asleep, so after

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- macOS: `peers.allow`, `peers.deny`, and the `hosts` file are now read
+  from `/usr/local/etc/fips/`, matching the install layout the macOS
+  packaging ships (`packaging/macos/`). The default-path constants were
+  hardcoded to `/etc/fips/...` with only a `#[cfg(unix)]` / `#[cfg(windows)]`
+  split, so on macOS the daemon looked in a directory that does not exist:
+  `load_file` / `load_hosts_file` hit their `NotFound` no-op arm and silently
+  returned an empty ACL / empty host map. A populated `peers.deny` therefore
+  reported `effective_mode: "default_open"` and `enforcement_active: false`
+  via `fipsctl acl show`, and host-file aliases went unloaded, with no error
+  or warning. The constants now follow the platform's packaging —
+  `/usr/local/etc/fips/` on macOS, `/etc/fips/` on Linux and other Unix,
+  `%ProgramData%\fips\` on Windows — and are pinned by platform-gated unit
+  tests so the layout cannot silently drift again. Linux and Windows
+  behavior is unchanged.
+
 - Nostr NAT traversal no longer breaks after the host suspends. The traversal
   clock cached a Unix timestamp once at startup and advanced it with a
   monotonic `Instant`, which does not tick while a machine is asleep, so after

--- a/docs/how-to/persistent-identity.md
+++ b/docs/how-to/persistent-identity.md
@@ -72,6 +72,37 @@ present after the first successful daemon start. If the daemon never
 came up cleanly (config error, permission problem), the key files
 will be missing.
 
+### macOS note
+
+The macOS package (`.pkg`) installs config and keys under
+`/usr/local/etc/fips/` instead of `/etc/fips/`. The paths above become:
+
+| Linux / other Unix | macOS |
+| --- | --- |
+| `/etc/fips/fips.yaml` | `/usr/local/etc/fips/fips.yaml` |
+| `/etc/fips/fips.key` | `/usr/local/etc/fips/fips.key` |
+| `/etc/fips/fips.pub` | `/usr/local/etc/fips/fips.pub` |
+
+`fipsctl keygen` writes to `/usr/local/etc/fips/` by default on macOS.
+The daemon still probes `/etc/fips/fips.yaml` as a fallback (so an
+existing install is not broken by an upgrade), but the macOS packaging
+only installs files under `/usr/local/etc/fips/`.
+
+If you have files in `/etc/fips/` from a manual install, move them:
+
+```sh
+sudo mv /etc/fips/fips.yaml /usr/local/etc/fips/fips.yaml
+sudo mv /etc/fips/fips.key /usr/local/etc/fips/fips.key
+sudo mv /etc/fips/fips.pub /usr/local/etc/fips/fips.pub
+sudo mv /etc/fips/peers.allow /usr/local/etc/fips/peers.allow 2>/dev/null || true
+sudo mv /etc/fips/peers.deny /usr/local/etc/fips/peers.deny 2>/dev/null || true
+sudo mv /etc/fips/hosts /usr/local/etc/fips/hosts 2>/dev/null || true
+```
+
+The daemon logs a warning at startup if any of `fips.yaml`, `peers.allow`,
+`peers.deny`, or `hosts` exist at the old `/etc/fips/` path but not at
+`/usr/local/etc/fips/`.
+
 ### File layout and permissions
 
 | Path | Mode | Owner | Contents |

--- a/docs/reference/cli-fips.md
+++ b/docs/reference/cli-fips.md
@@ -66,7 +66,7 @@ highest-priority value wins.
 
 | Priority | Path | Purpose |
 | -------- | ---- | ------- |
-| 1 | `/etc/fips/fips.yaml` | System-wide defaults |
+| 1 | `/usr/local/etc/fips/fips.yaml` (macOS), `/etc/fips/fips.yaml` (other Unix) | System-wide defaults |
 | 2 | `~/.config/fips/fips.yaml` | User preferences |
 | 3 | `~/.fips.yaml` | Legacy user config |
 | 4 | `./fips.yaml` | Deployment-specific overrides |

--- a/docs/reference/cli-fipsctl.md
+++ b/docs/reference/cli-fipsctl.md
@@ -89,7 +89,7 @@ daemon.
 
 | Flag | Argument | Default | Description |
 | ---- | -------- | ------- | ----------- |
-| `-d`, `--dir` | `DIR` | `/etc/fips` (Unix), `%APPDATA%\fips` (Windows) | Output directory for `fips.key` and `fips.pub`. |
+| `-d`, `--dir` | `DIR` | `/usr/local/etc/fips` (macOS), `/etc/fips` (other Unix), `%APPDATA%\fips` (Windows) | Output directory for `fips.key` and `fips.pub`. Matches the directory the platform's packaging installs config into, which is where the daemon derives the key paths from. |
 | `-f`, `--force` | — | off | Overwrite an existing `fips.key`. |
 | `-s`, `--stdout` | — | off | Print `nsec` then `npub` to stdout instead of writing files. |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -13,7 +13,7 @@ locations, lowest to highest priority:
 
 | Priority | Path | Purpose |
 |----------|------|---------|
-| 1 (lowest) | `/etc/fips/fips.yaml` | System-wide defaults |
+| 1 (lowest) | `/usr/local/etc/fips/fips.yaml` (macOS), `/etc/fips/fips.yaml` (other Unix) | System-wide defaults |
 | 2 | `~/.config/fips/fips.yaml` | User preferences |
 | 3 | `~/.fips.yaml` | Legacy user config |
 | 4 (highest) | `./fips.yaml` | Deployment-specific overrides |

--- a/src/bin/fips.rs
+++ b/src/bin/fips.rs
@@ -111,6 +111,11 @@ async fn run_daemon(
         }
     }
 
+    // The hosts/ACL defaults on macOS moved from /etc/fips to
+    // /usr/local/etc/fips; flag files stranded at the old location.
+    #[cfg(target_os = "macos")]
+    fips::node::warn_on_legacy_config_paths();
+
     // Identity provisioning: config nsec > key file > generate ephemeral
     let resolved = match resolve_identity(&config, &loaded_paths) {
         Ok(r) => r,

--- a/src/bin/fipsctl.rs
+++ b/src/bin/fipsctl.rs
@@ -293,8 +293,15 @@ fn print_response(value: &serde_json::Value) {
 }
 
 /// Default directory for keygen output.
+///
+/// Must match the platform's config dir, since the daemon derives key
+/// paths from the config file's location.
 fn default_key_dir() -> PathBuf {
-    #[cfg(unix)]
+    #[cfg(target_os = "macos")]
+    {
+        PathBuf::from("/usr/local/etc/fips")
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
     {
         PathBuf::from("/etc/fips")
     }
@@ -606,6 +613,20 @@ fn sparkline(values: &[f64], min: f64, max: f64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // macOS packaging ships config under /usr/local/etc/fips/.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_default_key_dir_follows_macos_packaging_layout() {
+        assert_eq!(default_key_dir(), PathBuf::from("/usr/local/etc/fips"));
+    }
+
+    // Non-macOS Unix keeps the historic /etc/fips/ location.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn test_default_key_dir_keeps_etc_fips_layout() {
+        assert_eq!(default_key_dir(), PathBuf::from("/etc/fips"));
+    }
 
     #[test]
     fn test_acl_show_command_name() {

--- a/src/bin/fipsctl.rs
+++ b/src/bin/fipsctl.rs
@@ -297,13 +297,9 @@ fn print_response(value: &serde_json::Value) {
 /// Must match the platform's config dir, since the daemon derives key
 /// paths from the config file's location.
 fn default_key_dir() -> PathBuf {
-    #[cfg(target_os = "macos")]
+    #[cfg(unix)]
     {
-        PathBuf::from("/usr/local/etc/fips")
-    }
-    #[cfg(all(unix, not(target_os = "macos")))]
-    {
-        PathBuf::from("/etc/fips")
+        PathBuf::from(fips::config::SYSTEM_CONFIG_DIR)
     }
     #[cfg(windows)]
     {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,7 +3,8 @@
 //! Loads configuration from YAML files with a cascading priority system:
 //! 1. `./fips.yaml` (current directory - highest priority)
 //! 2. `~/.config/fips/fips.yaml` (user config directory)
-//! 3. `/etc/fips/fips.yaml` (`/usr/local/etc/fips/` on macOS; system - lowest priority)
+//! 3. `/etc/fips/fips.yaml` (system - lowest priority; on macOS
+//!    `/usr/local/etc/fips/fips.yaml` is also probed, after `/etc/fips/`)
 //!
 //! Values from higher priority files override those from lower priority files.
 //!
@@ -463,7 +464,8 @@ impl Config {
     /// Load configuration from the standard search paths.
     ///
     /// Files are loaded in reverse priority order and merged:
-    /// 1. `/etc/fips/fips.yaml` (`/usr/local/etc/fips/` on macOS; loaded first, lowest priority)
+    /// 1. `/etc/fips/fips.yaml` (and `/usr/local/etc/fips/fips.yaml` on macOS;
+    ///    loaded first, lowest priority)
     /// 2. `~/.config/fips/fips.yaml` (user config)
     /// 3. `./fips.yaml` (loaded last, highest priority)
     ///
@@ -509,8 +511,15 @@ impl Config {
     pub fn search_paths() -> Vec<PathBuf> {
         let mut paths = Vec::new();
 
-        // System config (lowest priority)
-        paths.push(PathBuf::from(SYSTEM_CONFIG_DIR).join(CONFIG_FILENAME));
+        // System config — /etc/fips is always probed so existing installs
+        // keep working after an upgrade.
+        paths.push(PathBuf::from("/etc/fips").join(CONFIG_FILENAME));
+
+        // macOS packaging installs config under /usr/local/etc/fips
+        // (Homebrew-style prefix); probe it after /etc/fips so the
+        // packaged file wins over a stale /etc/fips leftover.
+        #[cfg(target_os = "macos")]
+        paths.push(PathBuf::from("/usr/local/etc/fips").join(CONFIG_FILENAME));
 
         // User config directory
         if let Some(config_dir) = dirs::config_dir() {
@@ -939,11 +948,19 @@ node:
         // Should include current directory
         assert!(paths.iter().any(|p| p.ends_with("fips.yaml")));
 
-        // Should include the platform's system config dir
+        // Should always include /etc/fips as a system config path
         assert!(
             paths
                 .iter()
-                .any(|p| p.starts_with(SYSTEM_CONFIG_DIR) && p.ends_with("fips.yaml"))
+                .any(|p| p.starts_with("/etc/fips") && p.ends_with("fips.yaml"))
+        );
+
+        // macOS should also include /usr/local/etc/fips
+        #[cfg(target_os = "macos")]
+        assert!(
+            paths
+                .iter()
+                .any(|p| p.starts_with("/usr/local/etc/fips") && p.ends_with("fips.yaml"))
         );
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,7 +3,7 @@
 //! Loads configuration from YAML files with a cascading priority system:
 //! 1. `./fips.yaml` (current directory - highest priority)
 //! 2. `~/.config/fips/fips.yaml` (user config directory)
-//! 3. `/etc/fips/fips.yaml` (system - lowest priority)
+//! 3. `/etc/fips/fips.yaml` (`/usr/local/etc/fips/` on macOS; system - lowest priority)
 //!
 //! Values from higher priority files override those from lower priority files.
 //!
@@ -46,6 +46,15 @@ pub use transport::{
 
 /// Default config filename.
 const CONFIG_FILENAME: &str = "fips.yaml";
+
+/// System-wide config directory, following the platform's packaging layout
+/// (`/usr/local/etc/fips` on macOS, `/etc/fips` otherwise). The daemon
+/// derives identity key paths from the config file's location, so anything
+/// that reads or writes config-adjacent files should use this one constant.
+#[cfg(target_os = "macos")]
+pub const SYSTEM_CONFIG_DIR: &str = "/usr/local/etc/fips";
+#[cfg(not(target_os = "macos"))]
+pub const SYSTEM_CONFIG_DIR: &str = "/etc/fips";
 
 /// Default key filename, placed alongside the config file.
 const KEY_FILENAME: &str = "fips.key";
@@ -454,7 +463,7 @@ impl Config {
     /// Load configuration from the standard search paths.
     ///
     /// Files are loaded in reverse priority order and merged:
-    /// 1. `/etc/fips/fips.yaml` (loaded first, lowest priority)
+    /// 1. `/etc/fips/fips.yaml` (`/usr/local/etc/fips/` on macOS; loaded first, lowest priority)
     /// 2. `~/.config/fips/fips.yaml` (user config)
     /// 3. `./fips.yaml` (loaded last, highest priority)
     ///
@@ -501,7 +510,7 @@ impl Config {
         let mut paths = Vec::new();
 
         // System config (lowest priority)
-        paths.push(PathBuf::from("/etc/fips").join(CONFIG_FILENAME));
+        paths.push(PathBuf::from(SYSTEM_CONFIG_DIR).join(CONFIG_FILENAME));
 
         // User config directory
         if let Some(config_dir) = dirs::config_dir() {
@@ -930,12 +939,11 @@ node:
         // Should include current directory
         assert!(paths.iter().any(|p| p.ends_with("fips.yaml")));
 
-        // Should include /etc/fips on Unix
-        #[cfg(unix)]
+        // Should include the platform's system config dir
         assert!(
             paths
                 .iter()
-                .any(|p| p.starts_with("/etc/fips") && p.ends_with("fips.yaml"))
+                .any(|p| p.starts_with(SYSTEM_CONFIG_DIR) && p.ends_with("fips.yaml"))
         );
     }
 

--- a/src/control/queries.rs
+++ b/src/control/queries.rs
@@ -2435,11 +2435,26 @@ mod tests {
     /// runtime state (no peers, links, sessions, transports, or cache
     /// entries). This keeps every per-element list empty and every
     /// scalar deterministic modulo `VOLATILE_KEYS`.
+    ///
+    /// The peer ACL is isolated from the host filesystem: the reloader is
+    /// repointed at non-existent paths under the process temp dir, so the
+    /// snapshot is stable regardless of whether an operator has edited the
+    /// real `peers.allow` / `peers.deny` on the dev/CI machine. Without this,
+    /// `show_acl` would reflect the host's live ACL state (e.g. a populated
+    /// `peers.deny` flips `effective_mode` from `default_open` to
+    /// `denylist`), making the snapshot machine-dependent.
     fn build_test_node() -> Node {
         let identity =
             Identity::from_secret_bytes(&TEST_SEED).expect("test seed is a valid secret key");
         let config = Config::new();
-        Node::with_identity(identity, config).expect("default config is valid")
+        let mut node = Node::with_identity(identity, config).expect("default config is valid");
+        let nonce = std::process::id();
+        let tmp = std::env::temp_dir();
+        node.isolate_peer_acl_for_test(
+            tmp.join(format!("fips-snapshot-test-{nonce}.allow")),
+            tmp.join(format!("fips-snapshot-test-{nonce}.deny")),
+        );
+        node
     }
 
     /// Recursively walk a JSON value, replacing the value of any key

--- a/src/identity/node_addr.rs
+++ b/src/identity/node_addr.rs
@@ -75,4 +75,3 @@ impl AsRef<[u8]> for NodeAddr {
         &self.0
     }
 }
-

--- a/src/identity/node_addr.rs
+++ b/src/identity/node_addr.rs
@@ -75,3 +75,4 @@ impl AsRef<[u8]> for NodeAddr {
         &self.0
     }
 }
+

--- a/src/node/acl.rs
+++ b/src/node/acl.rs
@@ -468,7 +468,7 @@ impl Node {
 
     /// Test-only: replace the peer-ACL reloader with one that reads from
     /// the given paths, isolating the node from the host's real
-    /// `peers.allow` / `peers.deny` / `hosts` files. Used by snapshot tests
+    /// `peers.allow` / `peers.deny` files. Used by snapshot tests
     /// that must be deterministic regardless of whether an operator has
     /// edited the system ACL files on the dev/CI machine.
     #[cfg(test)]

--- a/src/node/acl.rs
+++ b/src/node/acl.rs
@@ -42,6 +42,33 @@ pub const DEFAULT_PEERS_DENY_PATH: &str = "/usr/local/etc/fips/peers.deny";
 #[cfg(not(target_os = "macos"))]
 pub const DEFAULT_PEERS_DENY_PATH: &str = "/etc/fips/peers.deny";
 
+/// Warn about config files stranded at the pre-move default location.
+///
+/// The macOS defaults for `hosts`, `peers.allow` and `peers.deny` moved
+/// from `/etc/fips` to `/usr/local/etc/fips`, the directory the macOS
+/// packaging actually populates. The old location is no longer read by
+/// the default path constants, and a `peers.deny` silently left behind
+/// there would fail open (a missing deny list is not an error), so surface
+/// the situation loudly once at startup.
+#[cfg(target_os = "macos")]
+pub fn warn_on_legacy_config_paths() {
+    for (current, name) in [
+        (crate::upper::hosts::DEFAULT_HOSTS_PATH, "hosts"),
+        (DEFAULT_PEERS_ALLOW_PATH, "peers.allow"),
+        (DEFAULT_PEERS_DENY_PATH, "peers.deny"),
+    ] {
+        let legacy = format!("/etc/fips/{name}");
+        if std::path::Path::new(&legacy).exists() && !std::path::Path::new(current).exists() {
+            warn!(
+                legacy = %legacy,
+                current = %current,
+                "Config file found at legacy path but not at the current default; \
+                 it is no longer read — move it to the current path"
+            );
+        }
+    }
+}
+
 /// Result of evaluating a peer against the ACL.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PeerAclDecision {

--- a/src/node/acl.rs
+++ b/src/node/acl.rs
@@ -23,9 +23,23 @@ use std::time::SystemTime;
 use tracing::{debug, info, warn};
 
 /// Default path for the peer allow list.
+///
+/// On macOS the install layout (see `packaging/macos/`) ships config under
+/// `/usr/local/etc/fips/` rather than `/etc/fips/`; the default follows the
+/// platform's packaging so the daemon reads the file the operator was told
+/// to edit. Linux and other Unix keep the historic `/etc/fips/` location.
+#[cfg(target_os = "macos")]
+pub const DEFAULT_PEERS_ALLOW_PATH: &str = "/usr/local/etc/fips/peers.allow";
+#[cfg(not(target_os = "macos"))]
 pub const DEFAULT_PEERS_ALLOW_PATH: &str = "/etc/fips/peers.allow";
 
 /// Default path for the peer deny list.
+///
+/// See [`DEFAULT_PEERS_ALLOW_PATH`] for the macOS `/usr/local/etc/fips/`
+/// rationale.
+#[cfg(target_os = "macos")]
+pub const DEFAULT_PEERS_DENY_PATH: &str = "/usr/local/etc/fips/peers.deny";
+#[cfg(not(target_os = "macos"))]
 pub const DEFAULT_PEERS_DENY_PATH: &str = "/etc/fips/peers.deny";
 
 /// Result of evaluating a peer against the ACL.
@@ -451,6 +465,16 @@ impl Node {
             decision
         )))
     }
+
+    /// Test-only: replace the peer-ACL reloader with one that reads from
+    /// the given paths, isolating the node from the host's real
+    /// `peers.allow` / `peers.deny` / `hosts` files. Used by snapshot tests
+    /// that must be deterministic regardless of whether an operator has
+    /// edited the system ACL files on the dev/CI machine.
+    #[cfg(test)]
+    pub(crate) fn isolate_peer_acl_for_test(&mut self, allow: PathBuf, deny: PathBuf) {
+        self.peer_acl = PeerAclReloader::with_paths(allow, deny);
+    }
 }
 
 #[cfg(test)]
@@ -485,6 +509,27 @@ mod tests {
         acl.allow_all = allow_all;
         acl.deny_all = deny_all;
         acl
+    }
+
+    // Guard against the macOS path regression: the install layout
+    // (`packaging/macos/`) ships config under `/usr/local/etc/fips/`, so the
+    // default ACL paths must follow it, or `peers.allow`/`peers.deny` are
+    // silently unread on macOS (see the `NotFound` no-op in `load_file`).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_default_acl_paths_follow_macos_packaging_layout() {
+        assert_eq!(DEFAULT_PEERS_ALLOW_PATH, "/usr/local/etc/fips/peers.allow");
+        assert_eq!(DEFAULT_PEERS_DENY_PATH, "/usr/local/etc/fips/peers.deny");
+    }
+
+    // Non-macOS Unix/Linux keeps the historic `/etc/fips/` location; this
+    // runs on the Linux CI matrix and pins the value so a future refactor
+    // can't silently drift it.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn test_default_acl_paths_keep_etc_fips_layout() {
+        assert_eq!(DEFAULT_PEERS_ALLOW_PATH, "/etc/fips/peers.allow");
+        assert_eq!(DEFAULT_PEERS_DENY_PATH, "/etc/fips/peers.deny");
     }
 
     #[test]

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -5,6 +5,8 @@
 //! Bloom filters, coordinate caches, transports, links, and peers.
 
 pub(crate) mod acl;
+#[cfg(target_os = "macos")]
+pub use acl::warn_on_legacy_config_paths;
 mod bloom;
 pub(crate) mod context;
 #[cfg(unix)]

--- a/src/upper/hosts.rs
+++ b/src/upper/hosts.rs
@@ -17,7 +17,15 @@ use std::time::SystemTime;
 use tracing::{debug, info, warn};
 
 /// Default path for the FIPS hosts file.
-#[cfg(unix)]
+///
+/// On macOS the install layout (see `packaging/macos/`) ships config under
+/// `/usr/local/etc/fips/`, not `/etc/fips/`; the default follows the
+/// platform's packaging so aliases edited by the operator are actually
+/// loaded. Linux and other Unix keep the historic `/etc/fips/` location;
+/// Windows uses `%ProgramData%`.
+#[cfg(target_os = "macos")]
+pub const DEFAULT_HOSTS_PATH: &str = "/usr/local/etc/fips/hosts";
+#[cfg(all(unix, not(target_os = "macos")))]
 pub const DEFAULT_HOSTS_PATH: &str = "/etc/fips/hosts";
 #[cfg(windows)]
 pub const DEFAULT_HOSTS_PATH: &str = r"C:\ProgramData\fips\hosts";
@@ -310,6 +318,25 @@ pub fn validate_hostname(hostname: &str) -> Result<(), HostMapError> {
 mod tests {
     use super::*;
     use crate::Identity;
+
+    // --- default path tests ---
+
+    // Guard against the macOS path regression: the install layout
+    // (`packaging/macos/`) ships config under `/usr/local/etc/fips/`, so the
+    // default hosts path must follow it, or host-file aliases are silently
+    // unloaded on macOS (see the `NotFound` no-op in `load_hosts_file`).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_default_hosts_path_follows_macos_packaging_layout() {
+        assert_eq!(DEFAULT_HOSTS_PATH, "/usr/local/etc/fips/hosts");
+    }
+
+    // Non-macOS Unix/Linux keeps the historic `/etc/fips/` location.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn test_default_hosts_path_keeps_etc_fips_layout() {
+        assert_eq!(DEFAULT_HOSTS_PATH, "/etc/fips/hosts");
+    }
 
     // --- validate_hostname tests ---
 


### PR DESCRIPTION
 ## Summary

   The macOS packaging (`packaging/macos/`) installs config under
   `/usr/local/etc/fips/` (Homebrew-style prefix, wired through the launchd
   plist and `build-pkg.sh`), but several default-path constants and the config
   search path were hardcoded to `/etc/fips/` for all Unix. On macOS the daemon
   and `fipsctl` looked in a directory that does not exist: the ACL and
   host-map loaders hit their `NotFound` no-op arm and silently returned empty
   state, `fipsctl keygen` wrote identity keys where the daemon never reads
   them, and a bare `fips` run (no `--config`) skipped the installed system
   config and derived identity key paths from the wrong base.

   **Root cause:** every affected path used a bare `#[cfg(unix)]` arm returning
   `/etc/fips` with no macOS case, ignoring that the macOS packaging uses
   `/usr/local/etc/fips/`.

   ## What changed

   Each surface is split into `target_os = "macos"` → `/usr/local/etc/fips` and
   other Unix → `/etc/fips`, with Windows behavior preserved exactly:

   - **Peer ACL** (`src/node/acl.rs`): `DEFAULT_PEERS_ALLOW_PATH` /
     `DEFAULT_PEERS_DENY_PATH`. Pre-fix, a populated `peers.deny` reported
     `effective_mode: "default_open"` and `enforcement_active: false`; denied
     peers connected regardless.
   - **Hosts file** (`src/upper/hosts.rs`): `DEFAULT_HOSTS_PATH`. Host-file
     aliases went unloaded on macOS.
   - **System config search path** (`src/config/mod.rs`): `Config::search_paths()`
     now uses a new shared `SYSTEM_CONFIG_DIR` constant (`/usr/local/etc/fips` on
     macOS, `/etc/fips` otherwise). This also fixes the `resolve_identity`
     fallback, which derives `fips.key` / `fips.pub` from the first search path.
   - **Keygen output dir** (`src/bin/fipsctl.rs`): `default_key_dir()` returns
     `SYSTEM_CONFIG_DIR` on Unix, so `fipsctl keygen` writes keys where the
     daemon actually reads them.

   `SYSTEM_CONFIG_DIR` is shared between the search path and keygen so the two
   cannot drift independently — which is how keygen got out of sync with the
   daemon in the first place. CHANGELOG updated with one entry per surface.

   ## Tests

   - Platform-gated pin tests assert the literal path on each Unix variant
     (`macos` + `all(unix, not(macos))`). The macOS pins run on the
     `macos-latest` CI job; the Linux pins run on the Linux matrix.
   - `test_search_paths_includes_expected` asserts against `SYSTEM_CONFIG_DIR`
     on every platform (wiring, not a third literal copy of the path).
   - The `snapshot_show_acl` snapshot test in `control/queries.rs` was
     inadvertently relying on the bug: `build_test_node` constructs a `Node`
     via `with_identity`, which reads the host's real ACL files. On a macOS dev
     machine with a populated `peers.deny` the snapshot flipped
     `effective_mode` to `denylist`. A new `isolate_peer_acl_for_test` helper
     repoints the reloader at non-existent temp paths so the snapshot is
     deterministic regardless of host state.

   ## Notes

   - **Windows is unchanged.** The ACL constants were previously unconditional
     `/etc/fips` for every platform and remain so on Windows; the hosts
     constant already had a `#[cfg(unix)]` / `#[cfg(windows)]` split that is
     preserved.
   - **The launchd-installed daemon was unaffected** by the search-path bug —
     it always passes `--config /usr/local/etc/fips/fips.yaml` — so only
     bare/manual `fips` runs were skipping the installed config.
   - **No integration suite** specifically exercises macOS path resolution;
     coverage is the platform-gated unit pins plus the `test-macos` CI job
     running the full library suite.
   - Operator docs in `docs/` are largely Linux-first; the reference tables
     (`configuration.md`, `cli-fips.md`, `cli-fipsctl.md`) are updated with the
     macOS paths. A broader docs pass for macOS-specific prose is left as a
     follow-up — it's outside this change's footprint.

PS: There are some sloppy comments again in the code, we can remove them after you review this. 