### PR TITLE
transport: make address clones allocation-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `TransportAddr` clones now share immutable address bytes instead of
+  reallocating and copying them.
+
 - The Ethernet transport's per-interface `discovery` flag was renamed to
   `listen` (`transports.ethernet.*`) to match the symmetric `announce`
   (transmit) / `listen` (receive) neighbor-beacon vocabulary. The old

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,3 +124,8 @@ path = "src/bin/fipstop/main.rs"
 name = "routing_next_hop"
 path = "benches/routing_next_hop.rs"
 harness = false
+
+[[bench]]
+name = "transport_addr_clone"
+path = "benches/transport_addr_clone.rs"
+harness = false

--- a/benches/transport_addr_clone.rs
+++ b/benches/transport_addr_clone.rs
@@ -1,0 +1,37 @@
+//! Clone-cost comparison for transport address backing storage.
+//!
+//! The `Vec<u8>` case preserves the former `TransportAddr` clone operation;
+//! the shared case calls the current public `TransportAddr::clone` directly.
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use fips::TransportAddr;
+
+const ADDRESS_BYTES: [usize; 3] = [6, 18, 58];
+
+fn bench_transport_addr_clone(c: &mut Criterion) {
+    let mut group = c.benchmark_group("transport_addr_clone");
+
+    for len in ADDRESS_BYTES {
+        let bytes = vec![0x5a; len];
+        let former_vec_backed = bytes.clone();
+        let current_shared = TransportAddr::from_bytes(&bytes);
+
+        group.bench_with_input(BenchmarkId::new("former_vec_backed", len), &len, |b, _| {
+            b.iter(|| black_box(former_vec_backed.clone()))
+        });
+        group.bench_with_input(BenchmarkId::new("current_shared", len), &len, |b, _| {
+            b.iter(|| black_box(current_shared.clone()))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(50);
+    targets = bench_transport_addr_clone
+}
+criterion_main!(benches);

--- a/src/transport/types.rs
+++ b/src/transport/types.rs
@@ -8,6 +8,7 @@
 //! via `pub use types::*`, so existing `crate::transport::{LinkId, ...}`
 //! imports are unaffected.
 
+use alloc::{string::String, sync::Arc, vec::Vec};
 use core::fmt;
 use core::time::Duration;
 
@@ -91,23 +92,25 @@ impl fmt::Display for LinkDirection {
 /// Each transport type interprets this differently:
 /// - UDP/TCP: "host:port" (IP address or DNS hostname)
 /// - Ethernet: MAC address (6 bytes)
+///
+/// The immutable bytes are shared across clones.
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct TransportAddr(Vec<u8>);
+pub struct TransportAddr(Arc<[u8]>);
 
 impl TransportAddr {
     /// Create a transport address from raw bytes.
     pub fn new(bytes: Vec<u8>) -> Self {
-        Self(bytes)
+        Self(bytes.into())
     }
 
     /// Create a transport address from a byte slice.
     pub fn from_bytes(bytes: &[u8]) -> Self {
-        Self(bytes.to_vec())
+        Self(Arc::from(bytes))
     }
 
     /// Create a transport address from a string.
     pub fn from_string(s: &str) -> Self {
-        Self(s.as_bytes().to_vec())
+        Self(Arc::from(s.as_bytes()))
     }
 
     /// Get the raw bytes.
@@ -158,7 +161,7 @@ impl fmt::Display for TransportAddr {
                 Ok(())
             }
             None => {
-                for byte in &self.0 {
+                for byte in self.0.iter() {
                     write!(f, "{:02x}", byte)?;
                 }
                 Ok(())
@@ -175,7 +178,37 @@ impl From<&str> for TransportAddr {
 
 impl From<String> for TransportAddr {
     fn from(s: String) -> Self {
-        Self(s.into_bytes())
+        Self(s.into_bytes().into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::sync::Arc;
+
+    use super::TransportAddr;
+
+    #[test]
+    fn transport_addr_clone_shares_immutable_bytes() {
+        let addr = TransportAddr::from_string("192.168.1.1:2121");
+        let cloned = addr.clone();
+
+        assert_eq!(addr, cloned);
+        assert!(Arc::ptr_eq(&addr.0, &cloned.0));
+    }
+
+    #[test]
+    fn transport_addr_equality_and_hash_use_byte_values() {
+        use std::collections::HashSet;
+
+        let original = TransportAddr::from_string("192.168.1.1:2121");
+        let same_value = TransportAddr::from_bytes(b"192.168.1.1:2121");
+        let mut addrs = HashSet::new();
+
+        assert!(!Arc::ptr_eq(&original.0, &same_value.0));
+        assert_eq!(original, same_value);
+        addrs.insert(original);
+        assert!(addrs.contains(&same_value));
     }
 }
 


### PR DESCRIPTION
## What

`TransportAddr` is cloned in receive, handshake, and peer-bookkeeping paths. Its private `Vec<u8>` backing makes every clone allocate and copy the address.

Store the immutable bytes in `Arc<[u8]>` instead. Public construction, value equality and hashing, wire bytes, display, and `no_std + alloc` compatibility are unchanged.

## Measurement

The committed benchmark compares the former `Vec<u8>::clone` operation with the actual public `TransportAddr::clone`:

```sh
cargo bench --bench transport_addr_clone
```

Apple M4 Pro, macOS 26.6.1, Rust 1.94.1:

| Address bytes | Former | Shared | Change |
| ---: | ---: | ---: | ---: |
| 6 | 18.93 ns | 3.75 ns | -80.2% |
| 18 | 20.04 ns | 3.70 ns | -81.5% |
| 58 | 22.02 ns | 3.63 ns | -83.5% |

A counting pass measured 1 -> 0 allocations per clone. A separate lifecycle pass measured construct + one clone at 2 -> 1 allocations and 42.7-45.5 ns -> 23.7-25.0 ns.

As an end-to-end check, upstream's real-daemon Docker benchmark ran three ABBA blocks with six 10-second single-stream legs per mode. Throughput was 2,689 -> 2,675 Mbps (-0.5%) and combined endpoint CPU was 1.655 -> 1.660 CPU-sec/Gbit (+0.3%), with mixed block directions. The full-daemon effect is therefore neutral within noise; the claim is limited to removing clone allocation and cost.

## Testing

- `cargo bench --bench transport_addr_clone`
- `cargo test --lib` (1,645 passed, 4 ignored)
- `cargo check --all-targets`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
