### PR TITLE
fix(lookup): accept our own lookup response instead of relaying it away

### DIFF
--- a/docs/design/fips-mesh-operation.md
+++ b/docs/design/fips-mesh-operation.md
@@ -272,6 +272,17 @@ follows the same path as the request. Greedy tree routing toward the
 `origin_coords` is used only as a fallback if the reverse-path entry has
 expired.
 
+**Originator check first**: a node tests its own outstanding lookups before
+consulting `recent_requests`. A request is flooded to every bloom-matching
+tree peer, and a bloom false positive can send a copy out into the wider
+network and back to the originator, which would otherwise file its own
+`request_id` as an ordinary transit entry and relay its own answer away. The
+originator arm therefore wins: a response naming a target with a lookup
+outstanding, carrying a `request_id` that lookup issued, is accepted here
+whatever the dedup cache holds. A returning copy of the request is likewise
+dropped as a duplicate rather than recorded, so the originator's id never
+enters the transit cache.
+
 **Response-forwarded flag**: Each `recent_requests` entry tracks whether a
 response has already been forwarded for that `request_id`. If a second
 response arrives (e.g., from convergent request paths that reached the

--- a/src/proto/lookup/core.rs
+++ b/src/proto/lookup/core.rs
@@ -258,6 +258,26 @@ pub(crate) fn classify_request(
         };
     }
 
+    // A request this node originated, flooded to every bloom-matching tree
+    // peer and circulated back to us by one of them. The only identity test
+    // below is `request.target == *my_addr`, and for a lookup we originated
+    // the target is someone else, so without this the copy is filed as an
+    // ordinary transit entry keyed on our own `request_id` — and the answer,
+    // when it comes, is reverse-path forwarded to the peer that looped the
+    // request instead of being accepted here. Dropping it as the duplicate it
+    // is also stops the copy being forwarded a second time: our flood already
+    // reached the peers that could carry it.
+    if lookup
+        .pending_lookups
+        .get(&request.target)
+        .is_some_and(|pending| pending.matches(request.request_id))
+    {
+        return Classification {
+            outcome: RequestOutcome::Duplicate,
+            evicted: None,
+        };
+    }
+
     let evicted = make_room(lookup, from, max_recent, peer_count);
     lookup.record_recent(request.request_id, *from, now_ms);
 
@@ -278,8 +298,9 @@ pub(crate) fn classify_request(
     Classification { outcome, evicted }
 }
 
-/// How an inbound LookupResponse should be routed, decided from the
-/// recent-request dedup state.
+/// How an inbound LookupResponse should be routed, decided from the pending
+/// lookups this node has outstanding and, failing that, the recent-request
+/// dedup state.
 pub(crate) enum ResponseRoute {
     /// A response for a request we forwarded, but we already reverse-forwarded
     /// one for this request_id — drop to prevent response routing loops.
@@ -294,7 +315,8 @@ pub(crate) enum ResponseRoute {
     Unsolicited,
 }
 
-/// Classify an inbound LookupResponse against the recent-request dedup cache.
+/// Classify an inbound LookupResponse against the pending lookups and the
+/// recent-request dedup cache, in that order.
 ///
 /// Pure decision over `Lookup` state: sets `response_forwarded` when this is
 /// the first response we transit for the request. No I/O, no view, no metrics.
@@ -303,6 +325,30 @@ pub(crate) fn classify_response(
     request_id: u64,
     target: &NodeAddr,
 ) -> ResponseRoute {
+    // Originator-ness is decided first, ahead of the transit dedup record.
+    // The response names a target this node has a lookup outstanding for and
+    // carries an id that lookup issued, so it answers us whatever else the
+    // dedup cache happens to hold for that id. Testing `recent_requests`
+    // first instead made this arm unreachable whenever a copy of our own
+    // flooded request found its way back to us and was filed as transit: the
+    // reply was relayed away rather than accepted, the pending lookup was
+    // never satisfied, and discovery failed while the answers were arriving.
+    //
+    // The id is fresh 64-bit randomness drawn per attempt and the target
+    // signs over it, so a harvested response is bound to the request it
+    // answered and cannot be redirected or replayed: an id we never issued
+    // still cannot match, and preferring this arm takes nothing away from
+    // what the `Unsolicited` arm protects. Replies to earlier attempts of a
+    // still-outstanding lookup match too, which is the common case on a link
+    // whose round trip exceeds the first rung of the retry ladder.
+    if lookup
+        .pending_lookups
+        .get(target)
+        .is_some_and(|pending| pending.matches(request_id))
+    {
+        return ResponseRoute::Originator;
+    }
+
     match lookup.recent_requests.get_mut(&request_id) {
         Some(recent) => {
             if recent.response_forwarded {
@@ -314,25 +360,9 @@ pub(crate) fn classify_response(
                 }
             }
         }
-        // Not a request we transited, so it claims to answer one of ours.
-        // Require that it names a target with a lookup outstanding and carries
-        // an id issued for it. The id is fresh 64-bit randomness drawn per
-        // attempt and the target signs over it, so a harvested response is
-        // bound to the request it answered and cannot be redirected or
-        // replayed. Replies to earlier attempts of a still-outstanding lookup
-        // still match, which is the common case on a link whose round trip
-        // exceeds the first rung of the retry ladder.
-        None => {
-            let solicited = lookup
-                .pending_lookups
-                .get(target)
-                .is_some_and(|pending| pending.matches(request_id));
-            if solicited {
-                ResponseRoute::Originator
-            } else {
-                ResponseRoute::Unsolicited
-            }
-        }
+        // Neither a request we transited nor an answer to a lookup we have
+        // outstanding for its target. Nobody asked for it.
+        None => ResponseRoute::Unsolicited,
     }
 }
 

--- a/src/proto/lookup/tests/core.rs
+++ b/src/proto/lookup/tests/core.rs
@@ -152,8 +152,8 @@ fn classify_response_transit_on_fresh_forwarded_request() {
         .recent_requests
         .insert(42, RecentRequest::new(from_peer, 1000));
 
-    // Transit is decided by the dedup record alone, so the target the response
-    // names plays no part here — pass one no pending lookup mentions.
+    // With no lookup of ours outstanding for the target, transit is decided by
+    // the dedup record — pass a target no pending lookup mentions.
     match classify_response(&mut lookup, 42, &make_node_addr(0xF1)) {
         ResponseRoute::Transit { from_peer: peer } => assert_eq!(peer, from_peer),
         _ => panic!("expected Transit"),
@@ -179,6 +179,38 @@ fn classify_response_already_forwarded_on_second_call() {
         classify_response(&mut lookup, 7, &target),
         ResponseRoute::AlreadyForwarded
     ));
+}
+
+#[test]
+fn classify_response_originator_wins_over_a_transit_dedup_record() {
+    // Regression. A copy of a request we originated can be flooded back to us
+    // and filed in `recent_requests` as ordinary transit, keyed on our own
+    // request_id. Consulting the dedup record first then classified the answer
+    // as Transit and relayed it to the peer that looped the request, so the
+    // pending lookup was never satisfied and discovery failed with "no reply"
+    // while the responses were in fact arriving. Originator-ness wins.
+    let target = make_node_addr(0x61);
+    let looping_peer = make_node_addr(0x62);
+    let mut lookup = empty_lookup();
+    lookup
+        .recent_requests
+        .insert(4242, RecentRequest::new(looping_peer, 1000));
+    let mut pending = PendingLookup::new(1000);
+    pending.record(4242);
+    lookup.pending_lookups.insert(target, pending);
+
+    assert!(matches!(
+        classify_response(&mut lookup, 4242, &target),
+        ResponseRoute::Originator
+    ));
+    // And nothing was reverse-path forwarded on our behalf.
+    assert!(
+        !lookup
+            .recent_requests
+            .get(&4242)
+            .unwrap()
+            .response_forwarded
+    );
 }
 
 #[test]
@@ -440,6 +472,63 @@ fn classify_request_duplicate_on_second_call() {
         classify_request(&mut lookup, &request, &from, &my_addr, 1000, 5000, 4096, 1).outcome,
         RequestOutcome::Duplicate
     ));
+}
+
+#[test]
+fn classify_request_drops_our_own_request_looped_back_to_us() {
+    // Regression, request side of the same defect. Our flood reaches a peer
+    // that circulates it back; the only identity test is `target == my_addr`,
+    // which a lookup we originated never satisfies. Recording it would file
+    // our own request_id as a transit entry and hand the eventual answer to
+    // the looping peer, so the copy is dropped as the duplicate it is.
+    let mut lookup = empty_lookup();
+    let looping_peer = make_node_addr(0x01);
+    let my_addr = make_node_addr(0x99);
+    let target = make_node_addr(0xAA);
+    let mut pending = PendingLookup::new(1000);
+    pending.record(77);
+    lookup.pending_lookups.insert(target, pending);
+
+    let request = make_request_id(77, target, 3);
+    let classification = classify_request(
+        &mut lookup,
+        &request,
+        &looping_peer,
+        &my_addr,
+        1000,
+        5000,
+        4096,
+        1,
+    );
+    assert!(matches!(classification.outcome, RequestOutcome::Duplicate));
+    assert!(classification.evicted.is_none());
+    // Crucially, our own id must not enter the transit dedup cache.
+    assert!(!lookup.recent_requests.contains_key(&77));
+    assert!(lookup.recent_by_peer.is_empty());
+    // A response for it is then ours to accept.
+    assert!(matches!(
+        classify_response(&mut lookup, 77, &target),
+        ResponseRoute::Originator
+    ));
+}
+
+#[test]
+fn classify_request_still_transits_a_foreign_id_for_a_target_we_are_looking_up() {
+    // The guard keys on the id, not the target: another node's lookup for the
+    // same target must still be transited normally while ours is outstanding.
+    let mut lookup = empty_lookup();
+    let from = make_node_addr(0x01);
+    let my_addr = make_node_addr(0x99);
+    let target = make_node_addr(0xAA);
+    let mut pending = PendingLookup::new(1000);
+    pending.record(77);
+    lookup.pending_lookups.insert(target, pending);
+
+    let request = make_request_id(88, target, 3);
+    let outcome =
+        classify_request(&mut lookup, &request, &from, &my_addr, 1000, 5000, 4096, 1).outcome;
+    assert!(matches!(outcome, RequestOutcome::Forward));
+    assert_eq!(lookup.recent_requests.get(&88).unwrap().from_peer, from);
 }
 
 #[test]


### PR DESCRIPTION
## The defect

An originator could misfile the answer to its own lookup as transit. Discovery reported "requests went unanswered" while the replies were in fact arriving and being reverse-path forwarded to a peer.

A request is flooded to every tree peer whose bloom filter claims the target. At a high fill ratio a false positive sends a copy out into the wider network, which can circulate it back to the originator. On arrival `classify_request` applied its only identity test, `target == my_addr`, which a lookup we originated never satisfies — so the copy was recorded in `recent_requests` as an ordinary transit entry keyed on our own `request_id`. When the target answered, `classify_response` consulted `recent_requests` first, matched that entry, and relayed our own answer to the peer that looped the request. The pending lookup was never satisfied, the ladder retried with a fresh id, and the race repeated.

The `None` arm's reasoning — *"not a request we transited, so it claims to answer one of ours"* — held only while our own ids stayed out of the dedup cache, and nothing enforced that.

It is a race, not a hard failure: when the genuine reply beats the looped copy the cache is still clean and the lookup succeeds. It bites hardest at the junction between a quiet subtree and a dense public network, where a lookup for a descendant goes both correctly downward and outward through a false positive, and the wide network returns it first.

## Symptom

`fipsctl probe` on an affected node, repeatably:

```
bloom       ok        0.5s  claimed by a peer filter, 2 peers asked
discovery   failed   15.0s  a peer filter claimed this address; 4 requests went unanswered
overall     failed, 15499 ms
```

The counter tell is `resp_unsolicited` pinned at zero while `resp_received == resp_forwarded` exactly — control never reached the originator arm. Affected nodes showed `resp_accepted` at 1 of 291 (0.34%).

## The change

Two changes, on both sides of the invariant:

- **`classify_response`** tests the pending lookups before `recent_requests`. A response naming a target with a lookup outstanding, carrying an id that lookup issued, is ours whatever the dedup cache holds. The id is fresh 64-bit randomness per attempt and the target signs over it, so an id we never issued still cannot match — the replay properties the `Unsolicited` arm protects are unchanged.

- **`classify_request`** drops a request whose id a pending lookup for that target issued, rather than recording it. Our own id never enters the transit cache, so a duplicate reply cannot be misrouted after we accept the first, and the returning copy is not forwarded a second time. The guard keys on the id, so another node's lookup for the same target still transits normally.

Either alone fixes the reported failure. Both, because the `classify_response` ordering is the correct precedence and the `classify_request` guard restores the invariant the `None` arm's reasoning rested on.

## Tests

- `classify_response_originator_wins_over_a_transit_dedup_record` — the exact race: id present in both maps, asserts `Originator` and that `response_forwarded` stayed false.
- `classify_request_drops_our_own_request_looped_back_to_us` — asserts `Duplicate`, empty `recent_requests`/`recent_by_peer`, and that a later response classifies `Originator`.
- `classify_request_still_transits_a_foreign_id_for_a_target_we_are_looking_up` — guards against over-matching on target.
- `classify_response_transit_on_fresh_forwarded_request` pinned the old precedence in its comment; corrected, behaviour unchanged.

Full suite: 2138 passed, 0 failed. `cargo fmt --check` clean.

## Validation

A/B tested on the reporting deployment with two packages built off this same base, differing only by this commit. Baseline (`66f0de8a13`) reproduces the four-attempt ladder failure; with the fix (`04131017be`) discovery completes.

On the fixed build `req_initiated` and `req_duplicate` track one another — every lookup's own request coming back and being dropped by the new guard, direct evidence the loop is real.