### PR TITLE
netmon: fingerprint the path to each peer instead of the host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fingerprint, while a peer on the same LAN — reached by its subnet route, not
   the default route — is covered, as is a more specific route moving under a
   single peer. Peers joining and leaving are ignored on their own, being
-  ordinary node behaviour rather than a statement about the medium. A peer
+  ordinary node behaviour rather than a statement about the medium — except
+  that a peer seen for the first time is checked against its own
+  `connect()`-ed socket, and reported if that socket is pinned to a source the
+  routing table would no longer choose, so a medium change in the window
+  between a peer authenticating and the next sample is not adopted silently
+  while that peer sits stranded on the old path. A peer
   addressed by MAC, by `.onion` or Nym recipient, by a scoped IPv6 literal, or
   by a hostname it has not yet been heard from on, has no route to ask about
   and contributes nothing; a node with no peers detects nothing, having nothing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,13 +47,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Node lifecycle
 
 - Transport-medium change detection, controlled by the new `node.netmon.*`
-  block (on by default). The node samples a coarse fingerprint of its network
-  attachment — the source addresses the routing table would pick for an off-link
-  destination, plus the set of up, non-loopback interface addresses — and
-  reports a change once the picture settles. A handover is not atomic (the old
-  address goes, briefly nothing has a route, the new one arrives), so a short
-  debounce coalesces the burst into one event and a fingerprint that settles
-  back where it started reports nothing. Linux subscribes to `NETLINK_ROUTE`
+  block (on by default). For each peer whose transport address is a numeric IP
+  endpoint, the node asks the kernel which local address it would use to reach
+  *that peer* — a `connect(2)` on a UDP socket, which resolves the route and
+  sends nothing — and reports a change once some peer held across two
+  consecutive samples is reached from a different local address, or has stopped
+  being reachable at all. Asking the question per peer rather than about the
+  host is what keeps it quiet: a container bridge, a VPN, a `veth` pair or a
+  tunnel appearing is not the route to any peer and cannot move the
+  fingerprint, while a peer on the same LAN — reached by its subnet route, not
+  the default route — is covered, as is a more specific route moving under a
+  single peer. Peers joining and leaving are ignored on their own, being
+  ordinary node behaviour rather than a statement about the medium. A peer
+  addressed by MAC, by `.onion` or Nym recipient, by a scoped IPv6 literal, or
+  by a hostname it has not yet been heard from on, has no route to ask about
+  and contributes nothing; a node with no peers detects nothing, having nothing
+  bound to the old path to repair. The peer table is read through the node's
+  existing lock-free entity snapshot, so the detector stays a detached task
+  holding no node state. A handover is not atomic (the route goes, briefly
+  there is none, the new one arrives), so a short debounce coalesces the burst
+  into one event and a fingerprint that settles back where it started reports
+  nothing. Linux subscribes to `NETLINK_ROUTE`
   multicast (the groups `ip monitor` uses) and macOS and FreeBSD to a
   `PF_ROUTE` socket, both reacting to the kernel event in milliseconds; every
   other platform samples on a timer at `node.netmon.poll_interval_secs`, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### Node lifecycle
+
+- A heartbeat whose send failed no longer counts as one that was delivered.
+  The peer's "last heartbeat" timestamp was stamped before the send and left
+  alone whatever came back, so a failure suppressed the next attempt for a
+  full `node.heartbeat_interval_secs` even though the peer had heard nothing —
+  on a 10s interval against a 30s `link_dead_timeout_secs`, three failures in
+  a row were the whole budget. The timestamp now moves only on a send that
+  returned cleanly, and a separate record of the *attempt* spaces the retries
+  so a peer that keeps failing is retried in seconds rather than either
+  hammered every tick or left for a full interval. That retry spacing
+  applies to the failure path only: gating a healthy peer on it as well
+  would have floored `node.heartbeat_interval_secs` at two seconds, so a
+  configured value below that would silently not have been honoured.
+
+- A peer that rotates its address no longer keeps sending from a socket
+  aimed where it used to be. The authenticated-frame path updated the
+  peer's address and discarded the flag saying it had changed, so the
+  per-peer `connect()`-ed UDP socket stayed pinned to the old 5-tuple;
+  the sibling path already cleared it.
+
 #### Data plane
 
 - A per-peer `connect()`-ed UDP socket is no longer left pinned to an interface

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -250,6 +250,14 @@ on the same LAN, reached by its subnet route rather than the default route, is
 covered as well as one across the internet, and so is a more specific route
 moving under a single peer.
 
+The converse is the residual. The probe answers for the peer's *current*
+address, and that address is the source of the last authentic packet it sent,
+so a peer that roams between two of its own addresses which leave this host by
+different interfaces is indistinguishable from a local path move. The reaction
+is scoped to the peers named in the change, so such a peer moves nothing but
+its own send path — but it is the peer, not this host, that decided the
+fingerprint changed.
+
 Peers appearing and leaving are ignored on their own — that is ordinary node
 behaviour and says nothing about the medium. A peer seen for the first time is
 the one exception, and it is not judged against history but against its own

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -202,7 +202,7 @@ an interface arriving or leaving — and rebinds the send path immediately.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `node.netmon.enabled` | bool | `true` | Whether medium-change detection runs |
-| `node.netmon.poll_interval_secs` | u64 | `5` | How often the host's network attachment is sampled (backstop period where an event-driven backend exists) |
+| `node.netmon.poll_interval_secs` | u64 | `5` | How often the path to each peer is sampled (backstop period where an event-driven backend exists) |
 | `node.netmon.debounce_ms` | u64 | `250` | How long to wait for the picture to settle before acting (`0` disables) |
 
 Established UDP peers use a per-peer `connect()`-ed socket for the send fast
@@ -219,9 +219,34 @@ connected socket is reinstalled on a later tick) and heartbeats every peer on a
 connectionless transport at once so the far side re-pins to the new source
 address. A peer reached over TCP, Tor, Nym or BLE is left to its periodic
 heartbeat, since sending to it here would block the node's receive loop on a
-stream the medium change has very likely just stranded; those transports
-re-dial on send. No peering is torn down: sessions, tree positions and routes
-survive the switch.
+stream the medium change has very likely just stranded. No peering is torn
+down: sessions, tree positions and routes survive the switch.
+
+**What counts as a change.** For each peer whose transport address is a numeric
+IP endpoint, the node asks the kernel which local address it would use to reach
+*that peer* — a `connect(2)` on a UDP socket, which resolves the route and sends
+nothing. A change is reported when a peer present in two consecutive samples is
+now reached from a different local address, or has stopped being reachable at
+all.
+
+Because the question is asked per peer, an interface the node does not peer over
+cannot trigger anything: a container bridge, a VPN, a `veth` pair or a tunnel
+appearing is not the route to any peer, so it does not enter the sample. A peer
+on the same LAN, reached by its subnet route rather than the default route, is
+covered as well as one across the internet, and so is a more specific route
+moving under a single peer.
+
+Peers appearing and leaving are ignored on their own — that is ordinary node
+behaviour and says nothing about the medium. A peer whose address is not a
+probeable IP endpoint contributes nothing: a MAC on Ethernet or BLE, a `.onion`
+or Nym recipient reached through a local proxy, an IPv6 literal with a scope
+suffix, or a peer still carrying the hostname it was configured with (resolving
+one would put a DNS lookup on the sample path; the address becomes numeric as
+soon as an authenticated packet arrives from the peer). A node holding no peers
+detects nothing, which is correct — it has nothing bound to the old path.
+
+The cost is three syscalls per peer per sample, bounded by
+`node.limits.max_peers`, with no packets sent and no name resolution.
 
 Detection uses the best backend the platform has:
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -202,8 +202,22 @@ an interface arriving or leaving — and rebinds the send path immediately.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `node.netmon.enabled` | bool | `true` | Whether medium-change detection runs |
-| `node.netmon.poll_interval_secs` | u64 | `5` | How often the path to each peer is sampled (backstop period where an event-driven backend exists) |
-| `node.netmon.debounce_ms` | u64 | `250` | How long to wait for the picture to settle before acting (`0` disables) |
+| `node.netmon.poll_interval_secs` | u64 | `5` | How often the path to each peer is sampled (backstop period where an event-driven backend exists). **Must be at least 1 while `enabled`; `0` is refused at startup.** |
+| `node.netmon.debounce_ms` | u64 | `250` | How long to wait for the picture to settle before acting (`0` disables). **Refused at startup when `debounce_ms × 8` reaches `node.link_dead_timeout_secs`** — see below. |
+
+Both refusals stop the node rather than degrade it, so they are worth knowing
+before they are met.
+
+A handover is ridden out for up to **8** settling rounds (`MAX_DEBOUNCE_ROUNDS`)
+of `debounce_ms` each before a change is reported. If that worst case reaches
+`node.link_dead_timeout_secs`, the liveness reaper tears the peering down before
+the detector ever reports, so the machinery runs and cannot help — the node
+refuses to start rather than run in that shape. At the shipped defaults the
+margin is wide (8 × 250 ms = 2 s against 30 s), but the constraint couples two
+keys in different blocks: **shortening `link_dead_timeout_secs` for fast
+failover can make an untouched `debounce_ms` illegal.** The refusal names both
+values and the multiplier.
+
 
 Established UDP peers use a per-peer `connect()`-ed socket for the send fast
 path. `connect(2)` makes the kernel resolve the route once and pin the local

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -237,7 +237,15 @@ covered as well as one across the internet, and so is a more specific route
 moving under a single peer.
 
 Peers appearing and leaving are ignored on their own — that is ordinary node
-behaviour and says nothing about the medium. A peer whose address is not a
+behaviour and says nothing about the medium. A peer seen for the first time is
+the one exception, and it is not judged against history but against its own
+send path: if its `connect()`-ed socket is pinned to a source the routing table
+would no longer choose, it is reported. Without that, a medium change in the
+window between a peer authenticating and the detector's next sample would be
+the detector's first sight of that peer, and would be adopted silently while
+the peer's socket stayed pinned to the path the host had just left. A peer
+joining onto a path that has not moved has its socket pinned exactly where its
+traffic goes, so it still reports nothing. A peer whose address is not a
 probeable IP endpoint contributes nothing: a MAC on Ethernet or BLE, a `.onion`
 or Nym recipient reached through a local proxy, an IPv6 literal with a scope
 suffix, or a peer still carrying the hostname it was configured with (resolving

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1100,6 +1100,44 @@ impl Config {
             }
         }
 
+        // Medium-change detection. Both checks are about the detector being
+        // able to do its job at all, not about taste in numbers.
+        let netmon = &self.node.netmon;
+        if netmon.enabled {
+            if netmon.poll_interval_secs == 0 {
+                return Err(ConfigError::Validation(
+                    "`node.netmon.poll_interval_secs` must be at least 1; it is the backstop \
+                     period behind the kernel event source, and the only detection signal at \
+                     all on a platform without one"
+                        .to_string(),
+                ));
+            }
+            // A handover is ridden out for up to `MAX_DEBOUNCE_ROUNDS` rounds
+            // of `debounce_ms` before the change is reported. If that can
+            // outlast the liveness timeout, the reaper tears the peering down
+            // first and the detector never gets to rebind anything — the
+            // machinery runs and cannot help.
+            // Saturating: both operands are operator-supplied `u64`s, and an
+            // overflow here would wrap to a small number and silently accept
+            // the very configuration this refuses.
+            let worst_case_debounce_ms = netmon
+                .debounce_ms
+                .saturating_mul(u64::from(crate::node::netmon::MAX_DEBOUNCE_ROUNDS));
+            let dead_timeout_ms = self.node.link_dead_timeout_secs.saturating_mul(1000);
+            if dead_timeout_ms > 0 && worst_case_debounce_ms >= dead_timeout_ms {
+                return Err(ConfigError::Validation(format!(
+                    "`node.netmon.debounce_ms` = {} can hold a report for up to {}ms across \
+                     {} settling rounds, which meets or exceeds \
+                     `node.link_dead_timeout_secs` = {}s: the peering would be reaped \
+                     before the medium change was ever acted on",
+                    netmon.debounce_ms,
+                    worst_case_debounce_ms,
+                    crate::node::netmon::MAX_DEBOUNCE_ROUNDS,
+                    self.node.link_dead_timeout_secs,
+                )));
+            }
+        }
+
         let native = &self.node.native_api;
         // Both floors refuse a node that would start, answer every setup call
         // and then drop every datagram a peer sent. A zero `backlog` makes the
@@ -2330,6 +2368,65 @@ node:
         assert_eq!(config.node.lookup.attempt_timeouts_secs, vec![1, 2, 4, 8]);
         // The compat block is consumed by normalize.
         assert!(config.node.discovery.is_none());
+    }
+
+    #[test]
+    fn test_a_zero_netmon_poll_interval_is_refused() {
+        // It was silently clamped to 1s, so a typo produced a node that polled
+        // twenty times more often than asked and said nothing about it.
+        let mut config = Config::default();
+        config.node.netmon.poll_interval_secs = 0;
+
+        let err = config.validate().expect_err("validation should fail");
+        assert!(err.to_string().contains("poll_interval_secs"), "{}", err);
+    }
+
+    #[test]
+    fn test_a_zero_netmon_poll_interval_is_allowed_when_detection_is_off() {
+        // Nothing reads it, so refusing the node over it would be pedantry.
+        let mut config = Config::default();
+        config.node.netmon.enabled = false;
+        config.node.netmon.poll_interval_secs = 0;
+
+        config
+            .validate()
+            .expect("a disabled detector imposes no constraint on its own knobs");
+    }
+
+    #[test]
+    fn test_a_debounce_that_outlasts_the_dead_timeout_is_refused() {
+        // The detector rides out a handover for up to MAX_DEBOUNCE_ROUNDS
+        // rounds before reporting. If that can exceed the liveness timeout the
+        // peering is reaped first and the detector cannot help — the node runs
+        // the machinery and still takes the outage it was meant to prevent.
+        let mut config = Config::default();
+        config.node.link_dead_timeout_secs = 30;
+        // 8 rounds x 4000ms = 32s > 30s.
+        config.node.netmon.debounce_ms = 4000;
+
+        let err = config.validate().expect_err("validation should fail");
+        let msg = err.to_string();
+        assert!(msg.contains("debounce_ms"), "{}", msg);
+        assert!(msg.contains("link_dead_timeout_secs"), "{}", msg);
+        // This message is the whole diagnostic for the only refusal an operator
+        // reaches by editing `node.netmon.debounce_ms`, and substring
+        // assertions cannot see how it reads. A run of spaces mid-sentence is
+        // what a continuation join leaves behind, and rustfmt does not touch
+        // string literals, so nothing else would catch it.
+        assert!(
+            !msg.contains("  "),
+            "the refusal message has a run of literal spaces in it: {:?}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_the_default_netmon_block_validates() {
+        // The shipped defaults must not be a config the node refuses to start
+        // on, which is the failure mode a cross-field check invites.
+        Config::default()
+            .validate()
+            .expect("the default configuration must validate");
     }
 
     #[test]

--- a/src/control/snapshot.rs
+++ b/src/control/snapshot.rs
@@ -18,6 +18,7 @@
 //! also advances only on the tick.
 
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use crate::identity::NodeAddr;
@@ -629,6 +630,19 @@ pub(crate) struct PeerRow {
     pub is_parent: bool,
     pub is_child: bool,
     pub transport_addr: Option<String>,
+    /// The peer's current transport address as a numeric IP endpoint, when it
+    /// is one. Not rendered anywhere: this is the medium-change detector's
+    /// read of the peer table (see [`crate::node::netmon`]), carried here
+    /// because the detector is a detached task and this snapshot is the
+    /// node's existing lock-free read side.
+    ///
+    /// `None` covers everything that is not a probeable IP destination — a
+    /// MAC on Ethernet or BLE, a `.onion` or Nym recipient, a peer still
+    /// carrying the hostname it was configured with, an IPv6 literal with a
+    /// scope suffix. Typed rather than re-parsed from `transport_addr` above
+    /// so a change to that string's rendering cannot silently leave the
+    /// detector with nothing to probe.
+    pub probe_target: Option<SocketAddr>,
     pub link_info: Option<PeerLinkInfo>,
     pub tree_depth: Option<usize>,
     /// `effective_depth = tree_depth + link_cost` — the same quantity

--- a/src/control/snapshot.rs
+++ b/src/control/snapshot.rs
@@ -18,7 +18,7 @@
 //! also advances only on the tick.
 
 use std::collections::HashMap;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
 use crate::identity::NodeAddr;
@@ -643,6 +643,17 @@ pub(crate) struct PeerRow {
     /// so a change to that string's rendering cannot silently leave the
     /// detector with nothing to probe.
     pub probe_target: Option<SocketAddr>,
+    /// Source address this peer's per-peer `connect()`-ed UDP socket was
+    /// pinned to by `connect(2)`, when it has one. Also not rendered, and read by the same detector:
+    /// it is what the send path is *actually* using, as against the
+    /// `probe_target` lookup's answer for what the kernel would choose now.
+    ///
+    /// `None` where there is no such socket — every platform but Linux and
+    /// macOS, a peer on another transport, and a peer whose socket has not
+    /// been installed yet or was just released — and also where the kernel
+    /// declined to name a source, which is not an address and must not be
+    /// compared as one.
+    pub bound_source: Option<IpAddr>,
     pub link_info: Option<PeerLinkInfo>,
     pub tree_depth: Option<usize>,
     /// `effective_depth = tree_depth + link_cost` — the same quantity

--- a/src/control/snapshot.rs
+++ b/src/control/snapshot.rs
@@ -654,6 +654,19 @@ pub(crate) struct PeerRow {
     /// declined to name a source, which is not an address and must not be
     /// compared as one.
     pub bound_source: Option<IpAddr>,
+    /// Address this peer's transport is bound to, when that bind is not the
+    /// wildcard. Read by the same detector, which has to put its probe the
+    /// same constrained question the send path answers.
+    ///
+    /// `open_connected_fd` binds the transport's configured address verbatim
+    /// and only then connects, so a non-wildcard `bind_addr` pins the source
+    /// whatever the routing table says, while an unconstrained probe takes the
+    /// kernel's choice. Left unequal, those two answers differ permanently and
+    /// every first-seen peer reports a move that never happened.
+    ///
+    /// `None` for the wildcard bind, which is the default and the case where
+    /// the kernel chooses on both sides.
+    pub probe_bind: Option<IpAddr>,
     pub link_info: Option<PeerLinkInfo>,
     pub tree_depth: Option<usize>,
     /// `effective_depth = tree_depth + link_cost` — the same quantity

--- a/src/node/dataplane/encrypted.rs
+++ b/src/node/dataplane/encrypted.rs
@@ -264,6 +264,7 @@ impl Node {
         let ce_flag = header.flags & FLAG_CE != 0;
         let sp_flag = header.flags & FLAG_SP != 0;
 
+        let mut address_changed = false;
         if let Some(peer) = self.peers.get_mut(&node_addr) {
             if let Some(mmp) = peer.mmp_mut() {
                 mmp.receiver.record_recv(
@@ -275,11 +276,27 @@ impl Node {
                 );
                 let _spin_rtt = mmp.spin_bit.rx_observe(sp_flag, header.counter, now_ms);
             }
-            peer.set_current_addr(packet.transport_id, packet.remote_addr.clone());
+            address_changed =
+                peer.set_current_addr(packet.transport_id, packet.remote_addr.clone());
             peer.link_stats_mut()
                 .record_recv(packet.data.len(), packet.timestamp_ms);
             peer.touch(packet.timestamp_ms);
         }
+
+        // Address rotation invalidates the per-peer connect()-ed UDP socket,
+        // which is still pinned to the old 5-tuple. The decrypt-worker
+        // completion path already does this; this one discarded the flag, so a
+        // peer that roamed kept sending from a socket aimed where it used to
+        // be. `netmon`'s first-sight rule now rests on this too: it compares
+        // that socket's pinned source against a probe to the peer's *current*
+        // address, and a socket left behind makes those two disagree for as
+        // long as it survives.
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        if address_changed {
+            self.clear_connected_udp_for_peer(&node_addr);
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        let _ = address_changed;
 
         // Dispatch to link message handler
         self.dispatch_link_message(&node_addr, link_message, ce_flag)

--- a/src/node/handlers/mmp.rs
+++ b/src/node/handlers/mmp.rs
@@ -20,6 +20,21 @@ use crate::transport::{TransportAddr, TransportId};
 use std::time::{Duration, Instant};
 use tracing::{debug, info, trace, warn};
 
+/// How long a peer whose heartbeat send *failed* waits before the next attempt.
+///
+/// Applies to the failure path only. Gating a healthy peer on it too would
+/// floor `node.heartbeat_interval_secs` at this value without validating or
+/// reporting it, which is a configured knob quietly not doing what it says.
+///
+/// Short against `heartbeat_interval_secs`, because a failed heartbeat means
+/// the peer has heard nothing and the point is to recover well inside
+/// `link_dead_timeout_secs` rather than after another full interval. Not
+/// shorter still, because the send behind it awaits an unbounded `write_all`
+/// on a connection-oriented transport, on the rx loop; retrying that every
+/// tick would make a stranded stream a stalled node. Once that write is
+/// bounded this can come down to the tick.
+const HEARTBEAT_RETRY_INTERVAL: Duration = Duration::from_secs(2);
+
 /// Emit the operator `trace!` point for a processed ReceiverReport outcome.
 ///
 /// These log points used to live inside `MmpMetrics::process_receiver_report`;
@@ -473,11 +488,42 @@ impl Node {
                     && peer.rekey_msg1_resend_count() < max_resends
                     && peer.rekey_msg1().is_some();
 
-                // Check if heartbeat is due.
-                let heartbeat_due = match peer.last_heartbeat_sent() {
+                // Check if heartbeat is due. Two gates, not one. The first is
+                // the interval since a heartbeat last *landed*; a send that
+                // failed does not satisfy it, so a peer that has heard nothing
+                // stays due instead of being suppressed for a full interval by
+                // an attempt that went nowhere.
+                //
+                // The second spaces the retries out. Without it a peer whose
+                // send keeps failing would be retried on every tick, and the
+                // send behind this is not always cheap: on a connection-oriented
+                // transport it awaits an unbounded `write_all` on the rx loop.
+                // Until that is bounded, retrying a failing peer once a second
+                // would turn a stranded stream into a stalled node.
+                let heartbeat_landed_due = match peer.last_heartbeat_sent() {
                     None => true,
                     Some(last) => now.duration_since(last) >= heartbeat_interval,
                 };
+                // The retry gate applies only after a *failure*. A successful
+                // send stamps both timestamps with the same instant, so on a
+                // healthy peer an unconditional gate would floor the configured
+                // interval at HEARTBEAT_RETRY_INTERVAL — silently turning a
+                // configured `heartbeat_interval_secs` of 1 into 2, with no
+                // validation refusing the value and nothing saying why. An
+                // attempt strictly newer than the last success is the only
+                // state that means "the last one did not land".
+                let last_attempt_failed =
+                    match (peer.last_heartbeat_attempt(), peer.last_heartbeat_sent()) {
+                        (Some(attempt), Some(sent)) => attempt > sent,
+                        (Some(_), None) => true,
+                        _ => false,
+                    };
+                let retry_due = !last_attempt_failed
+                    || match peer.last_heartbeat_attempt() {
+                        None => true,
+                        Some(last) => now.duration_since(last) >= HEARTBEAT_RETRY_INTERVAL,
+                    };
+                let heartbeat_due = heartbeat_landed_due && retry_due;
 
                 PeerLivenessSnapshot {
                     peer: *node_addr,
@@ -513,14 +559,25 @@ impl Node {
                     self.route_link_dead(peer, now_ms).await;
                 }
                 MmpAction::Heartbeat { peer } => {
+                    // Attempt first, success after: the attempt is recorded
+                    // even if the send below fails or never returns, so the
+                    // retry stays spaced; only a send that came back clean
+                    // moves the interval that says the peer has heard from us.
                     if let Some(p) = self.peers.get_mut(&peer) {
-                        p.mark_heartbeat_sent(now);
+                        p.mark_heartbeat_attempt(now);
                     }
-                    if let Err(e) = self
+                    match self
                         .send_encrypted_link_message(&peer, &heartbeat_msg)
                         .await
                     {
-                        trace!(peer = %self.peer_display_name(&peer), error = %e, "Failed to send heartbeat");
+                        Ok(()) => {
+                            if let Some(p) = self.peers.get_mut(&peer) {
+                                p.mark_heartbeat_sent(now);
+                            }
+                        }
+                        Err(e) => {
+                            trace!(peer = %self.peer_display_name(&peer), error = %e, "Failed to send heartbeat");
+                        }
                     }
                 }
                 MmpAction::SendLinkReport { .. }

--- a/src/node/handlers/netmon.rs
+++ b/src/node/handlers/netmon.rs
@@ -130,7 +130,10 @@ impl Node {
 
     /// Send one heartbeat to every peer whose send path cannot block, so each
     /// learns the node's new source address in one RTT rather than at the next
-    /// due interval. Returns how many went out.
+    /// due interval. Returns how many sends actually succeeded, which is what
+    /// the operator log reports — a count of peers *selected* would read the
+    /// same whether every frame left or none did, and a medium change is
+    /// exactly when sends start failing.
     ///
     /// The filter is not an optimisation. A connectionless transport's send
     /// completes without ever awaiting the wire: the UDP fast path hands the
@@ -158,7 +161,7 @@ impl Node {
     /// dropping the stale connection
     /// rather than writing into it, which is a different change with a real
     /// cost behind it — a Tor peer pays a fresh circuit — and is not this one.
-    async fn heartbeat_all_peers_after_net_change(&mut self) -> usize {
+    pub(in crate::node) async fn heartbeat_all_peers_after_net_change(&mut self) -> usize {
         let now = Instant::now();
         let heartbeat = [LinkMessageType::Heartbeat.to_byte()];
         let targets: Vec<NodeAddr> = self
@@ -172,17 +175,25 @@ impl Node {
             .map(|(addr, _)| *addr)
             .collect();
 
-        let sent = targets.len();
+        let mut sent = 0usize;
         for addr in targets {
             if let Some(peer) = self.peers.get_mut(&addr) {
-                peer.mark_heartbeat_sent(now);
+                peer.mark_heartbeat_attempt(now);
             }
-            if let Err(e) = self.send_encrypted_link_message(&addr, &heartbeat).await {
-                debug!(
-                    peer = %self.peer_display_name(&addr),
-                    error = %e,
-                    "Failed to send post-medium-change heartbeat"
-                );
+            match self.send_encrypted_link_message(&addr, &heartbeat).await {
+                Ok(()) => {
+                    if let Some(peer) = self.peers.get_mut(&addr) {
+                        peer.mark_heartbeat_sent(now);
+                    }
+                    sent += 1;
+                }
+                Err(e) => {
+                    debug!(
+                        peer = %self.peer_display_name(&addr),
+                        error = %e,
+                        "Failed to send post-medium-change heartbeat"
+                    );
+                }
             }
         }
         sent

--- a/src/node/handlers/netmon.rs
+++ b/src/node/handlers/netmon.rs
@@ -52,6 +52,23 @@
 //! position and the routes all survive the switch. `link_dead_timeout_secs`
 //! remains the backstop for a peer that genuinely cannot be reached on the new
 //! medium.
+//!
+//! # Why the reaction is still node-wide
+//!
+//! [`NetChange`] now names the peers whose local source address moved, because
+//! the fingerprint is keyed on them. The reaction deliberately does not use
+//! that yet: it drops every connected socket and heartbeats every
+//! connectionless peer, exactly as it did when the detector could only say
+//! "something about this host moved".
+//!
+//! That is over-broad and known to be. It is left node-wide here because
+//! narrowing it is a behavioural change with its own failure mode — a peer
+//! left un-rebound because it was absent from the moved set is stranded for
+//! `link_dead_timeout_secs`, which is the bug this subsystem exists to close —
+//! and it wants its own tests rather than a free ride on a change to the
+//! fingerprint. The cost of staying broad is now small: a change is only
+//! reported when a peering's own path moved, so the fan-out no longer fires
+//! for a container bridge appearing.
 
 use std::time::Instant;
 
@@ -64,6 +81,9 @@ use crate::proto::link::LinkMessageType;
 
 impl Node {
     /// React to a settled transport-medium change.
+    ///
+    /// `change.summary` names the peers that moved; see the module docs for
+    /// why the reaction is node-wide regardless.
     pub(in crate::node) async fn handle_net_change(&mut self, change: NetChange) {
         let peers = self.peers.len();
         // Before the heartbeats: they must go out over a socket that resolves
@@ -129,9 +149,13 @@ impl Node {
     /// sender record.
     ///
     /// So a peer on TCP, Tor, Nym or BLE keeps the periodic heartbeat it had
-    /// before this detector existed. It is not stranded by the omission: those
-    /// transports re-dial on send, and `link_dead_timeout_secs` remains the
-    /// backstop. Doing better for them means dropping the stale connection
+    /// before this detector existed, and `link_dead_timeout_secs` remains the
+    /// backstop. Note that it does *not* recover by redialling: `send_async`
+    /// only dials when the pool holds no connection for the address, and a
+    /// connection stranded by a medium change is still in the pool. It is
+    /// evicted after a write to it fails, so the redial happens on the send
+    /// after the failure, not on the first one. Doing better for them means
+    /// dropping the stale connection
     /// rather than writing into it, which is a different change with a real
     /// cost behind it — a Tor peer pays a fresh circuit — and is not this one.
     async fn heartbeat_all_peers_after_net_change(&mut self) -> usize {

--- a/src/node/handlers/netmon.rs
+++ b/src/node/handlers/netmon.rs
@@ -53,22 +53,22 @@
 //! remains the backstop for a peer that genuinely cannot be reached on the new
 //! medium.
 //!
-//! # Why the reaction is still node-wide
+//! # Why the reaction is scoped to the peers that moved
 //!
-//! [`NetChange`] now names the peers whose local source address moved, because
-//! the fingerprint is keyed on them. The reaction deliberately does not use
-//! that yet: it drops every connected socket and heartbeats every
-//! connectionless peer, exactly as it did when the detector could only say
-//! "something about this host moved".
+//! [`NetChange`] names them, and the reaction acts on exactly that set. It is
+//! not an optimisation: keying the sample on peers put the trigger within
+//! reach of a remote party for the first time. `probe_target` is the observed
+//! source address of every authentic packet, updated with no throttle, so a
+//! peer alternating between two addresses that resolve to different local
+//! sources can move the fingerprint at will. Node-wide, that peer could drive
+//! every other peering's socket teardown, bounded only by the poll interval.
+//! Scoped, the only peer in the set is the roamer itself — whose connected
+//! socket `dataplane::encrypted` has already cleared on the address change.
 //!
-//! That is over-broad and known to be. It is left node-wide here because
-//! narrowing it is a behavioural change with its own failure mode — a peer
-//! left un-rebound because it was absent from the moved set is stranded for
-//! `link_dead_timeout_secs`, which is the bug this subsystem exists to close —
-//! and it wants its own tests rather than a free ride on a change to the
-//! fingerprint. The cost of staying broad is now small: a change is only
-//! reported when a peering's own path moved, so the fan-out no longer fires
-//! for a container bridge appearing.
+//! Nothing is left stranded by the narrowing, because a peer absent from the
+//! set is one whose local source address the kernel still resolves to the same
+//! place. That is the whole content of the fingerprint: a peer that did not
+//! move is a peer whose socket is not stale.
 
 use std::time::Instant;
 
@@ -80,22 +80,21 @@ use crate::node::netmon::NetChange;
 use crate::proto::link::LinkMessageType;
 
 impl Node {
-    /// React to a settled transport-medium change.
-    ///
-    /// `change.summary` names the peers that moved; see the module docs for
-    /// why the reaction is node-wide regardless.
+    /// React to a settled transport-medium change, on the peers it names.
     pub(in crate::node) async fn handle_net_change(&mut self, change: NetChange) {
+        let moved: Vec<NodeAddr> = change.summary.moved.iter().map(|m| m.peer).collect();
         let peers = self.peers.len();
         // Before the heartbeats: they must go out over a socket that resolves
         // the route now, not one still pinned to the interface just left.
-        let sockets_rebound = self.drop_connected_sockets_after_net_change();
+        let sockets_rebound = self.drop_connected_sockets_after_net_change(&moved);
 
-        let heartbeated = self.heartbeat_all_peers_after_net_change().await;
+        let heartbeated = self.heartbeat_moved_peers_after_net_change(&moved).await;
 
         info!(
             generation = change.generation,
             change = %change.summary,
             peers,
+            moved = moved.len(),
             sockets_rebound,
             heartbeated,
             "Transport medium changed; rebinding sends and re-pinning peers"
@@ -109,12 +108,15 @@ impl Node {
     /// source address to the interface that carried the route at connect time,
     /// and never re-evaluates it.
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    fn drop_connected_sockets_after_net_change(&mut self) -> usize {
-        let pinned: Vec<NodeAddr> = self
-            .peers
+    fn drop_connected_sockets_after_net_change(&mut self, moved: &[NodeAddr]) -> usize {
+        let pinned: Vec<NodeAddr> = moved
             .iter()
-            .filter(|(_, peer)| peer.connected_udp().is_some())
-            .map(|(addr, _)| *addr)
+            .filter(|addr| {
+                self.peers
+                    .get(*addr)
+                    .is_some_and(|peer| peer.connected_udp().is_some())
+            })
+            .copied()
             .collect();
         for addr in &pinned {
             self.clear_connected_udp_for_peer(addr);
@@ -124,7 +126,7 @@ impl Node {
 
     /// No per-peer connected sockets on this platform, so nothing to rebind.
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-    fn drop_connected_sockets_after_net_change(&mut self) -> usize {
+    fn drop_connected_sockets_after_net_change(&mut self, _moved: &[NodeAddr]) -> usize {
         0
     }
 
@@ -161,18 +163,22 @@ impl Node {
     /// dropping the stale connection
     /// rather than writing into it, which is a different change with a real
     /// cost behind it — a Tor peer pays a fresh circuit — and is not this one.
-    pub(in crate::node) async fn heartbeat_all_peers_after_net_change(&mut self) -> usize {
+    pub(in crate::node) async fn heartbeat_moved_peers_after_net_change(
+        &mut self,
+        moved: &[NodeAddr],
+    ) -> usize {
         let now = Instant::now();
         let heartbeat = [LinkMessageType::Heartbeat.to_byte()];
-        let targets: Vec<NodeAddr> = self
-            .peers
+        let targets: Vec<NodeAddr> = moved
             .iter()
-            .filter(|(_, peer)| {
-                peer.transport_id()
-                    .and_then(|id| self.transports.get(&id))
-                    .is_some_and(|t| !t.transport_type().connection_oriented)
+            .filter(|addr| {
+                self.peers.get(*addr).is_some_and(|peer| {
+                    peer.transport_id()
+                        .and_then(|id| self.transports.get(&id))
+                        .is_some_and(|t| !t.transport_type().connection_oriented)
+                })
             })
-            .map(|(addr, _)| *addr)
+            .copied()
             .collect();
 
         let mut sent = 0usize;

--- a/src/node/lifecycle/mod.rs
+++ b/src/node/lifecycle/mod.rs
@@ -1944,7 +1944,8 @@ impl Node {
         // not health.
         let netmon_cfg = self.config().node.netmon.clone();
         if netmon_cfg.enabled {
-            let (rx, task) = crate::node::netmon::spawn_detector(netmon_cfg);
+            let (rx, task) =
+                crate::node::netmon::spawn_detector(netmon_cfg, self.entities_snapshot.clone());
             self.supervisor.netmon_rx = Some(rx);
             self.supervisor.netmon_task = Some(task);
         } else {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -2212,6 +2212,15 @@ impl Node {
                     bound_source: peer.connected_udp().and_then(|s| s.pinned_source()),
                     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
                     bound_source: None,
+                    probe_bind: peer
+                        .transport_id()
+                        .and_then(|id| self.transports.get(&id))
+                        .and_then(|t| match t {
+                            TransportHandle::Udp(u) => u.local_addr(),
+                            _ => None,
+                        })
+                        .map(|sa| sa.ip())
+                        .filter(|ip| !ip.is_unspecified()),
                     link_info,
                     tree_depth: peer.coords().map(|c| c.depth()),
                     effective_depth,

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -2208,6 +2208,10 @@ impl Node {
                         .current_addr()
                         .and_then(|a| a.as_str())
                         .and_then(|s| s.parse::<std::net::SocketAddr>().ok()),
+                    #[cfg(any(target_os = "linux", target_os = "macos"))]
+                    bound_source: peer.connected_udp().and_then(|s| s.pinned_source()),
+                    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+                    bound_source: None,
                     link_info,
                     tree_depth: peer.coords().map(|c| c.depth()),
                     effective_depth,

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -2204,6 +2204,10 @@ impl Node {
                     is_parent,
                     is_child,
                     transport_addr: peer.current_addr().map(|a| format!("{}", a)),
+                    probe_target: peer
+                        .current_addr()
+                        .and_then(|a| a.as_str())
+                        .and_then(|s| s.parse::<std::net::SocketAddr>().ok()),
                     link_info,
                     tree_depth: peer.coords().map(|c| c.depth()),
                     effective_depth,

--- a/src/node/netmon/mod.rs
+++ b/src/node/netmon/mod.rs
@@ -213,12 +213,18 @@ struct PeerPath {
 impl NetFingerprint {
     /// Probe every target and record the local address the kernel picks.
     ///
-    /// Three non-blocking syscalls per target — a bind, a `connect(2)` that
-    /// sends no packet, and a `getsockname` — with no I/O wait, no name
-    /// resolution and no allocation beyond the map. Bounded by
-    /// `node.limits.max_peers`, so a full table is a few hundred syscalls on a
-    /// multi-second timer; it runs inline in the detector's task rather than
-    /// through `spawn_blocking`.
+    /// Five non-blocking syscalls per target: `socket(2)` and `bind(2)` behind
+    /// `UdpSocket::bind`, a `connect(2)` that sends no packet, a
+    /// `getsockname(2)`, and the `close(2)` the socket takes on drop. No I/O
+    /// wait, no name resolution, and no allocation beyond the map.
+    ///
+    /// The count matters because a debounced handover resamples: up to
+    /// `MAX_DEBOUNCE_ROUNDS` rounds plus the settled sample, times the peers
+    /// held. `node.limits.max_peers` bounds that only where it is set —
+    /// the value 0 means unlimited, and there the cost tracks the live peer
+    /// count instead. It runs inline in the detector's own task rather than
+    /// through `spawn_blocking`, which is what keeps it off every other task
+    /// regardless.
     pub(in crate::node) fn sample(targets: &[ProbeTarget]) -> Self {
         Self {
             sources: targets
@@ -309,16 +315,35 @@ impl NetFingerprint {
     /// a peer joining onto a path that has not moved has `bound == current` and
     /// reports nothing.
     ///
-    /// A new peer with no connected socket (`bound` is `None`) is still
-    /// skipped, and is the residual. It is a much smaller one: with no socket
-    /// there is no pinning to repair, since the wildcard socket resolves a
-    /// route per packet, so the peer is not stranded. It costs only the
-    /// immediate heartbeat that would have told the far side to re-pin, leaving
-    /// it to notice at the next `heartbeat_interval_secs`.
+    /// A first-seen peer with no `bound` is still skipped, and that is the
+    /// residual. It covers three groups, and they are not equally harmless.
+    ///
+    /// Where there is genuinely no connected socket — every platform but Linux
+    /// and macOS, and every peer on a stream or proxied transport on those two
+    /// — nothing is pinned to repair, because the wildcard socket resolves a
+    /// route per packet. Such a peer is not stranded; it loses only the
+    /// immediate heartbeat that would have told the far side to re-pin, and
+    /// notices at its next `heartbeat_interval_secs`.
+    ///
+    /// The third group is a real hole rather than a harmless one, and it is one
+    /// tick wide. The tick publishes the entity snapshot before it installs
+    /// connected sockets (`record_stats_history` then
+    /// `activate_connected_udp_sessions`, in that order), so a socket installed
+    /// on tick N is first visible to this detector in the snapshot published on
+    /// tick N+1. A peer that joins and has its socket installed, and whose path
+    /// then moves before that next publish, is first seen with `bound` still
+    /// `None` and is skipped — and it *does* hold a pinned socket. About one
+    /// `tick_interval_secs` per join against a `poll_interval_secs` five times
+    /// longer, and the peer is recovered by the ordinary diff on the sample
+    /// after, so it is bounded rather than permanent.
+    ///
+    /// A non-wildcard `transports.udp.bind_addr` is not part of the residual;
+    /// see [`ProbeTarget::bind`], which keeps both sides answering the same
+    /// question rather than skipping the peer.
     ///
     /// An empty result means nothing moved; it is the detector's entire
     /// definition of "no change".
-    fn moved(&self, next: &Self) -> Vec<PeerSourceMove> {
+    pub(in crate::node) fn moved(&self, next: &Self) -> Vec<PeerSourceMove> {
         next.sources
             .iter()
             .filter_map(|(peer, now)| {
@@ -403,26 +428,24 @@ impl fmt::Display for NetChangeSummary {
             if i > 0 {
                 write!(f, ", ")?;
             }
-            match (m.before, m.after) {
-                (_, Some(after)) => write!(f, "{} -> {}", short(&m.peer), after)?,
-                (_, None) => write!(f, "{} -> no route", short(&m.peer))?,
-            }
+            // Both ends: the address the stale `connect(2)` had pinned is what
+            // an operator correlates against route history, so a line naming
+            // only the destination leaves out the half being diagnosed.
+            let before = match m.before {
+                Some(ip) => ip.to_string(),
+                None => "no route".to_string(),
+            };
+            let after = match m.after {
+                Some(ip) => ip.to_string(),
+                None => "no route".to_string(),
+            };
+            write!(f, "{} {} -> {}", m.peer.short_hex(), before, after)?;
         }
         if self.moved.len() > NAMED {
             write!(f, ", +{} more", self.moved.len() - NAMED)?;
         }
         Ok(())
     }
-}
-
-/// First four bytes of a `NodeAddr` in hex — enough to pick a peer out of a
-/// log without making the line unreadable.
-fn short(addr: &NodeAddr) -> String {
-    addr.as_bytes()
-        .iter()
-        .take(4)
-        .map(|b| format!("{:02x}", b))
-        .collect()
 }
 
 /// One settled transport-medium change, as delivered to the rx loop.

--- a/src/node/netmon/mod.rs
+++ b/src/node/netmon/mod.rs
@@ -27,13 +27,14 @@
 //! | macOS, FreeBSD | `PF_ROUTE` socket | kernel event, ~ms |
 //! | everything else | timer, `node.netmon.poll_interval_secs` | up to one period |
 //!
-//! Both kernel sources are [`crate::transport::watcher::LinkWatcher`], shared
-//! with the interface binder. It is asked for a wider set of netlink groups
-//! here than the binder asks for: presence is a link question, but a default
-//! route moving between two interfaces that both stay up emits nothing in the
-//! link group, so a presence subscription would never fire for the change this
-//! detector exists to catch. `PF_ROUTE` has no group selection and delivers
-//! everything regardless.
+//! Both kernel sources are [`crate::transport::watcher::LinkWatcher`], which
+//! this module is currently the only consumer of. It is asked for
+//! [`groups::EGRESS_PATH`](crate::transport::watcher::groups::EGRESS_PATH)
+//! rather than the watcher's default link-presence mask: a route moving
+//! between two interfaces that both stay up emits nothing in the link group, so
+//! a presence subscription would never fire for the change this detector exists
+//! to catch. `PF_ROUTE` has no group selection and delivers everything
+//! regardless.
 //!
 //! Still to come, behind the same seam and without touching the handler:
 //! `NotifyIpInterfaceChange` on Windows, and an embedder push on iOS. Android
@@ -47,42 +48,88 @@
 //!
 //! # What the fingerprint captures
 //!
-//! Two independent signals, because neither alone is sufficient:
+//! One local source address per peer: for every peer whose transport address is
+//! a numeric IP endpoint, the address the kernel would pick to reach *that
+//! peer*. A connected-but-never-sending UDP socket makes the kernel run its
+//! route lookup and bind the source address it would use; three syscalls, no
+//! packets, no name resolution, and it works identically on every platform std
+//! supports.
 //!
-//! - **The preferred source addresses.** A connected-but-never-sending UDP
-//!   socket makes the kernel run its route lookup and pick the source address
-//!   it *would* use to reach an off-link destination. That address changes
-//!   exactly when the default route moves between media, which is the
-//!   WLAN → 5G case. It costs two syscalls and no packets, and works
-//!   identically on every platform std supports.
-//! - **The set of up, non-loopback interface addresses**, on unix, where
-//!   `getifaddrs(3)` is available through the `libc` dependency the crate
-//!   already carries. This catches a medium arriving or leaving without
-//!   displacing the default route. A peer on the same LAN is reached by the
-//!   on-link subnet route, and the probe above follows the *default* route by
-//!   construction, so it looks straight past that path: unplug a LAN cable on
-//!   a host whose default route is cellular and the source addresses do not
-//!   move, while every connected socket to that peer is stranded.
+//! That set is exactly the quantity the reaction cares about. The stale
+//! `connect(2)` this whole subsystem exists to repair pinned a *local source
+//! address chosen for one destination*, so measuring the same thing for the
+//! same destinations asks the kernel the question the bug is about, rather
+//! than a proxy for it.
 //!
-//!   It is a proxy for "could the local end of one of our peerings have
-//!   moved", and a broad one — it enumerates every address the host has,
-//!   rather than the local end of the peerings the node actually holds, so a
-//!   container bridge or a tunnel interface appearing moves it too.
+//! Two consequences fall out of aiming the probe at peers rather than at the
+//! host:
 //!
-//! On platforms without `getifaddrs` (Windows) only the source-address probe
-//! contributes, which still catches every default-route move. The native
-//! backend is the answer there, not a richer sample.
+//! - **Interfaces the node does not peer over cannot move it.** A container
+//!   bridge, a VPN coming up, a `veth` pair, a tunnel — none of them is the
+//!   route to any peer, so none of them enters the fingerprint. This is by
+//!   construction rather than by a filter that has to keep guessing which
+//!   interface names are infrastructure, which is what the host-wide address
+//!   set this replaced could never get right: on a host running containers it
+//!   moved, and the node dropped every connected socket and heartbeated every
+//!   peer, for a `docker compose up`.
+//! - **On-link peers are visible.** A peer on the same LAN is reached by its
+//!   subnet route, not the default route, so a host-wide probe at an off-link
+//!   destination looked straight past it: unplug the LAN cable on a host whose
+//!   default route is cellular and nothing host-wide moved while every socket
+//!   to that peer was stranded. Its own probe follows its own route and moves.
+//!
+//! It is also the right granularity for a *more specific* route changing under
+//! one peer while the rest of the host is untouched, which no single host-wide
+//! sample can represent at all.
 //!
 //! # What it deliberately does not capture
 //!
-//! A BLE adapter's state is invisible to both signals — it is not an IP
-//! attachment at all. That signal comes from the radio (BlueZ properties, the
-//! Android callback) and belongs on this same channel, pushed by the BLE
+//! **A peer whose address is not a probeable IP destination** contributes
+//! nothing — an Ethernet or BLE peer addressed by MAC, a `.onion` or a Nym
+//! recipient reached through a local proxy, an IPv6 literal carrying a scope
+//! suffix. None of them is IP-attached in the way this detector reasons about,
+//! and the connected-UDP pinning it repairs cannot happen to them.
+//!
+//! **A peer still carrying the hostname it was configured with**, because
+//! resolving one on the sample path would put a DNS lookup, with its timeouts,
+//! inside the detector's tick. In practice the window is small: the address is
+//! replaced by the observed numeric source the first time an authenticated
+//! packet arrives (`dataplane::encrypted`), and a peer that has never been
+//! heard from has no established peering to strand.
+//!
+//! **A node with no peers** has an empty fingerprint and detects nothing, which
+//! is correct — there is nothing bound to the old path to repair.
+//!
+//! **A BLE adapter's state** is invisible here, as it was before: it is not an
+//! IP attachment at all. That signal comes from the radio (BlueZ properties,
+//! the Android callback) and belongs on this same channel, pushed by the BLE
 //! transport rather than sampled here.
-
-use std::collections::BTreeSet;
+//!
+//! # Where the peer list comes from
+//!
+//! [`crate::control::snapshot::EntitySnapshot`], the node's existing lock-free
+//! read side, republished from the tick. The detector is deliberately a
+//! detached task holding no node state and taking no node lock, so it reads
+//! the peer table the same way the off-loop `show_peers` renderer does. The
+//! view is at most one `node.tick_interval_secs` stale, which does not matter:
+//! a peer that has just appeared is absorbed on the next sample (see below),
+//! and one that has just left is dropped from the comparison rather than
+//! reported.
+//!
+//! # Comparing two samples
+//!
+//! Over the **intersection** of the two peer sets, never their union: a change
+//! is reported when some peer present in both samples is now reached from a
+//! different local address. Peers joining and leaving is ordinary node
+//! behaviour and says nothing about the medium, so on its own it must not fire
+//! a reaction that drops every connected socket. A peer whose probe stops
+//! answering entirely — the route to it is gone — is a move to "no source
+//! address" and does count, because that peer is exactly the one now stranded.
+//!
+use std::collections::BTreeMap;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
+use std::sync::Arc;
 use std::time::Duration;
 
 #[cfg(unix)]
@@ -92,18 +139,8 @@ use tokio::task::JoinHandle;
 use tracing::{debug, trace, warn};
 
 use crate::config::NetmonConfig;
-
-/// Off-link IPv4 probe destination — RFC 5737 TEST-NET-1, which is guaranteed
-/// not to be routed anywhere. Nothing is ever sent to it; `connect(2)` on a UDP
-/// socket only resolves the route and binds a source address.
-const PROBE_V4: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)), 9);
-
-/// Off-link IPv6 probe destination — RFC 3849 documentation prefix. Same
-/// no-packets-sent contract as [`PROBE_V4`].
-const PROBE_V6: SocketAddr = SocketAddr::new(
-    IpAddr::V6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 1)),
-    9,
-);
+use crate::control::snapshot::EntitySnapshot;
+use crate::identity::NodeAddr;
 
 /// How many resample rounds the debounce will ride out before reporting
 /// anyway. A handover emits a burst (address gone, address added, route
@@ -131,118 +168,135 @@ pub(crate) type NetChangeRx = mpsc::Receiver<NetChange>;
 /// Sender held by a detection backend.
 pub(crate) type NetChangeTx = mpsc::Sender<NetChange>;
 
-/// A coarse fingerprint of how this host is attached to the network.
+/// Where this host sits relative to the peers it holds: one local source
+/// address per peer, as the routing table would choose it right now.
 ///
-/// Equality is the whole point: the poller reports a change iff two
-/// consecutive samples differ. The contents are only ever used for the
-/// operator-facing description of what moved.
+/// The contents are compared over the intersection of two samples' peer sets —
+/// see [`NetFingerprint::moved`], which is the whole definition of "the medium
+/// changed" and the only thing the detector asks of a sample.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct NetFingerprint {
-    /// Source address the routing table would pick for an off-link IPv4
-    /// destination. `None` when there is no IPv4 route at all — itself a
-    /// meaningful state, and distinct from any address.
-    v4_source: Option<IpAddr>,
-    /// IPv6 counterpart of `v4_source`.
-    v6_source: Option<IpAddr>,
-    /// Every up, non-loopback unicast address on the host. Always empty on
-    /// platforms with no `getifaddrs`, which makes the fingerprint degrade to
-    /// the source-address probe rather than to nothing.
-    local_addrs: BTreeSet<IpAddr>,
+    /// Peer → the local address the kernel would send to it from. A peer whose
+    /// route lookup fails maps to `None`, which is a distinct and meaningful
+    /// value rather than an absent key: the peer is still ours, and having no
+    /// route to it is precisely the state worth reacting to. A peer with no
+    /// probeable address never appears at all.
+    sources: BTreeMap<NodeAddr, Option<IpAddr>>,
 }
 
 impl NetFingerprint {
-    /// Sample the host's current attachment.
+    /// Probe every target and record the local address the kernel picks.
     ///
-    /// Every call is a handful of non-blocking syscalls — a bind, a connect
-    /// that sends no packet, a `getifaddrs` walk — with no I/O wait, no name
-    /// resolution, and no allocation beyond the address set. It is called from
-    /// a dedicated task on a multi-second timer, so it runs inline rather than
+    /// Three non-blocking syscalls per target — a bind, a `connect(2)` that
+    /// sends no packet, and a `getsockname` — with no I/O wait, no name
+    /// resolution and no allocation beyond the map. Bounded by
+    /// `node.limits.max_peers`, so a full table is a few hundred syscalls on a
+    /// multi-second timer; it runs inline in the detector's task rather than
     /// through `spawn_blocking`.
-    pub(crate) fn sample() -> Self {
+    pub(crate) fn sample(targets: &[(NodeAddr, SocketAddr)]) -> Self {
         Self {
-            v4_source: preferred_source(PROBE_V4),
-            v6_source: preferred_source(PROBE_V6),
-            local_addrs: interface_addrs(),
+            sources: targets
+                .iter()
+                .map(|(peer, dest)| (*peer, preferred_source(*dest)))
+                .collect(),
         }
     }
 
     /// Build a fingerprint directly, so a test can script a sequence of
-    /// samples instead of reading the host's real attachment.
+    /// samples instead of probing real peers.
     #[cfg(test)]
-    pub(crate) fn for_test(v4_source: Option<IpAddr>, local_addrs: &[IpAddr]) -> Self {
+    pub(crate) fn for_test(sources: &[(NodeAddr, Option<IpAddr>)]) -> Self {
         Self {
-            v4_source,
-            v6_source: None,
-            local_addrs: local_addrs.iter().copied().collect(),
+            sources: sources.iter().copied().collect(),
         }
     }
 
-    /// Describe the transition from `self` to `next` for the operator log.
-    fn diff(&self, next: &Self) -> NetChangeSummary {
-        NetChangeSummary {
-            added: next
-                .local_addrs
-                .difference(&self.local_addrs)
-                .copied()
-                .collect(),
-            removed: self
-                .local_addrs
-                .difference(&next.local_addrs)
-                .copied()
-                .collect(),
-            v4_source_moved: self.v4_source != next.v4_source,
-            v6_source_moved: self.v6_source != next.v6_source,
-            v4_source: next.v4_source,
-            v6_source: next.v6_source,
-        }
+    /// Which peers held by *both* samples are now reached from a different
+    /// local address.
+    ///
+    /// The intersection is the point. A peer that has only just been
+    /// authenticated, or one that has just been reaped, differs between the two
+    /// samples for reasons that have nothing to do with the host's attachment,
+    /// and the reaction — drop every connected socket, heartbeat every peer —
+    /// is far too blunt to fire on ordinary peer churn. So a key missing from
+    /// either side is skipped, and only a peer observed twice can report
+    /// anything.
+    ///
+    /// An empty result means nothing moved; it is the detector's entire
+    /// definition of "no change".
+    fn moved(&self, next: &Self) -> Vec<PeerSourceMove> {
+        self.sources
+            .iter()
+            .filter_map(|(peer, before)| next.sources.get(peer).map(|after| (peer, before, after)))
+            .filter(|(_, before, after)| before != after)
+            .map(|(peer, before, after)| PeerSourceMove {
+                peer: *peer,
+                before: *before,
+                after: *after,
+            })
+            .collect()
     }
 }
 
-/// What moved between two fingerprints. Operator-facing only — the handler
-/// re-evaluates everything regardless of which field changed, because it
-/// cannot map an address back to the peers that were reaching over it.
+/// One peer whose local source address changed between two samples.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PeerSourceMove {
+    /// The peer that is now reached from somewhere else.
+    pub peer: NodeAddr,
+    /// The local address it was reached from, or `None` if there was no route.
+    pub before: Option<IpAddr>,
+    /// The local address it is reached from now, or `None` if the route is gone.
+    pub after: Option<IpAddr>,
+}
+
+/// What moved between two fingerprints.
+///
+/// Operator-facing, and — unlike the host-wide summary this replaced — it now
+/// names the peers affected, because the fingerprint is keyed on them. The
+/// handler still re-evaluates every peer regardless; narrowing the reaction to
+/// exactly [`Self::moved`] is a separate change.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct NetChangeSummary {
-    /// Local addresses present now but not before.
-    pub added: Vec<IpAddr>,
-    /// Local addresses present before but not now.
-    pub removed: Vec<IpAddr>,
-    /// The preferred IPv4 source address changed (a default-route move).
-    pub v4_source_moved: bool,
-    /// The preferred IPv6 source address changed.
-    pub v6_source_moved: bool,
-    /// The preferred IPv4 source address as of this sample.
-    pub v4_source: Option<IpAddr>,
-    /// The preferred IPv6 source address as of this sample.
-    pub v6_source: Option<IpAddr>,
+    /// Every peer whose local source address changed, in `NodeAddr` order.
+    pub moved: Vec<PeerSourceMove>,
+    /// How many peers were probed in the newer of the two samples, so a log
+    /// line shows what fraction of the table moved.
+    pub probed: usize,
 }
 
 impl fmt::Display for NetChangeSummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut parts: Vec<String> = Vec::new();
-        if self.v4_source_moved {
-            parts.push(match self.v4_source {
-                Some(ip) => format!("v4 source -> {}", ip),
-                None => "v4 source lost".to_string(),
-            });
-        }
-        if self.v6_source_moved {
-            parts.push(match self.v6_source {
-                Some(ip) => format!("v6 source -> {}", ip),
-                None => "v6 source lost".to_string(),
-            });
-        }
-        if !self.added.is_empty() {
-            parts.push(format!("+{} addr", self.added.len()));
-        }
-        if !self.removed.is_empty() {
-            parts.push(format!("-{} addr", self.removed.len()));
-        }
-        if parts.is_empty() {
+        if self.moved.is_empty() {
             return write!(f, "no visible difference");
         }
-        write!(f, "{}", parts.join(", "))
+        write!(f, "{}/{} peers: ", self.moved.len(), self.probed)?;
+        // Bounded: an operator needs the shape of the change, and a full table
+        // moving at once is the common case rather than the interesting one.
+        const NAMED: usize = 3;
+        for (i, m) in self.moved.iter().take(NAMED).enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            match (m.before, m.after) {
+                (_, Some(after)) => write!(f, "{} -> {}", short(&m.peer), after)?,
+                (_, None) => write!(f, "{} -> no route", short(&m.peer))?,
+            }
+        }
+        if self.moved.len() > NAMED {
+            write!(f, ", +{} more", self.moved.len() - NAMED)?;
+        }
+        Ok(())
     }
+}
+
+/// First four bytes of a `NodeAddr` in hex — enough to pick a peer out of a
+/// log without making the line unreadable.
+fn short(addr: &NodeAddr) -> String {
+    addr.as_bytes()
+        .iter()
+        .take(4)
+        .map(|b| format!("{:02x}", b))
+        .collect()
 }
 
 /// One settled transport-medium change, as delivered to the rx loop.
@@ -259,15 +313,16 @@ pub(crate) struct NetChange {
 impl NetChange {
     /// A synthetic change, for tests that exercise the node's *reaction* to a
     /// medium change rather than its detection. The summary is empty because
-    /// the handler never reads it — it re-evaluates every peer regardless of
-    /// which address moved, having no way to map an address back to the peers
-    /// that were reaching over it.
+    /// the handler does not read it — it re-evaluates every peer regardless of
+    /// which peer's source address moved.
     #[cfg(test)]
     pub(crate) fn for_test(generation: u64) -> Self {
-        let empty = NetFingerprint::default();
         Self {
             generation,
-            summary: empty.diff(&empty),
+            summary: NetChangeSummary {
+                moved: Vec::new(),
+                probed: 0,
+            },
         }
     }
 }
@@ -407,13 +462,33 @@ impl WakeSource {
 /// reaction is "re-evaluate every peer and every backoff", which subsumes any
 /// number of coalesced changes. A full channel therefore drops rather than
 /// queues, and never applies backpressure to the detector.
-pub(crate) fn spawn_detector(cfg: NetmonConfig) -> (NetChangeRx, JoinHandle<()>) {
+pub(crate) fn spawn_detector(
+    cfg: NetmonConfig,
+    peers: Arc<arc_swap::ArcSwap<EntitySnapshot>>,
+) -> (NetChangeRx, JoinHandle<()>) {
     let (tx, rx) = mpsc::channel(1);
     let handle = tokio::spawn(async move {
         let wake = build_wake_source(&cfg);
-        run_detector(tx, cfg, NetFingerprint::sample, wake).await;
+        let sample = move || NetFingerprint::sample(&probe_targets(&peers.load()));
+        run_detector(tx, cfg, sample, wake).await;
     });
     (rx, handle)
+}
+
+/// The peers worth probing, read off the node's published entity snapshot.
+///
+/// Every peer carrying a numeric IP endpoint, paired with it. The filter is
+/// [`crate::control::snapshot::PeerRow::probe_target`] being `Some`, which is
+/// already exactly "this peer is an IP destination we could `connect(2)` to":
+/// a MAC, a `.onion`, a Nym recipient and an unresolved hostname all arrive
+/// here as `None` and are skipped, with no per-transport special-casing in
+/// this module.
+pub(in crate::node) fn probe_targets(snapshot: &EntitySnapshot) -> Vec<(NodeAddr, SocketAddr)> {
+    snapshot
+        .peers
+        .iter()
+        .filter_map(|row| row.probe_target.map(|dest| (row.node_addr, dest)))
+        .collect()
 }
 
 /// Pick the wake source: the event-driven backend where one exists and starts,
@@ -484,29 +559,42 @@ where
         wake.wait().await;
 
         let mut candidate = sample();
-        if candidate == last {
+        if last.moved(&candidate).is_empty() {
+            // Nothing the node is peering over moved. Adopt the sample anyway:
+            // it is how a peer that has just joined enters the comparison, and
+            // one that has left leaves it. Skipping this would freeze `last` on
+            // the peer set the detector started with, and a peer authenticated
+            // later would never be compared against anything.
+            last = candidate;
             continue;
         }
 
         // The picture is moving. Ride out the burst: resample after the
         // debounce window until two consecutive samples agree, so the reported
         // change is against a settled state rather than a mid-handover one.
+        // Settling is judged the same way — no peer moved since the previous
+        // round — so peers joining or leaving mid-handover cannot extend the
+        // debounce on their own either.
         for _ in 0..MAX_DEBOUNCE_ROUNDS {
             if debounce.is_zero() {
                 break;
             }
             tokio::time::sleep(debounce).await;
             let resampled = sample();
-            if resampled == candidate {
+            let settled = candidate.moved(&resampled).is_empty();
+            candidate = resampled;
+            if settled {
                 break;
             }
-            candidate = resampled;
         }
 
-        // The burst may have settled back to where it started (an address that
-        // flapped away and returned). Nothing changed, so nothing is reported.
-        if candidate == last {
+        // The burst may have settled back to where it started (a route that
+        // flapped away and returned). Nothing moved, so nothing is reported —
+        // but the sample is still adopted, for the reason above.
+        let moved = last.moved(&candidate);
+        if moved.is_empty() {
             trace!("Network fingerprint settled back unchanged; no event");
+            last = candidate;
             continue;
         }
 
@@ -524,7 +612,10 @@ where
         generation += 1;
         let change = NetChange {
             generation,
-            summary: last.diff(&candidate),
+            summary: NetChangeSummary {
+                moved,
+                probed: candidate.sources.len(),
+            },
         };
         last = candidate;
 
@@ -547,9 +638,14 @@ where
 /// The source address the kernel would use to reach `probe`.
 ///
 /// `connect(2)` on a UDP socket is a pure routing-table operation: it resolves
-/// the route, binds a source address, and sends nothing. A failure — most often
-/// `ENETUNREACH` with no route of that family — is itself a fingerprint value,
-/// reported as `None` rather than swallowed.
+/// the route, binds a source address, and sends nothing. The socket is dropped
+/// here and never written to, so a peer is probed without a single packet
+/// reaching it.
+///
+/// A failure — most often `ENETUNREACH`, no route to that peer at all — is
+/// itself a fingerprint value, reported as `None` rather than swallowed. It is
+/// the state a stranded peer is in, so losing it would blind the detector to
+/// the case it most needs to see.
 fn preferred_source(probe: SocketAddr) -> Option<IpAddr> {
     let bind: SocketAddr = match probe {
         SocketAddr::V4(_) => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
@@ -564,85 +660,6 @@ fn preferred_source(probe: SocketAddr) -> Option<IpAddr> {
         return None;
     }
     Some(local)
-}
-
-/// Every up, non-loopback unicast address on the host.
-#[cfg(unix)]
-fn interface_addrs() -> BTreeSet<IpAddr> {
-    let mut out = BTreeSet::new();
-    let mut head: *mut libc::ifaddrs = std::ptr::null_mut();
-
-    // SAFETY: `getifaddrs` either returns 0 and writes an owned linked list
-    // into `head`, or returns non-zero and leaves `head` untouched — so the
-    // list is only walked on success. Every node is read behind a null check,
-    // and `freeifaddrs` releases the list exactly once, after the walk.
-    if unsafe { libc::getifaddrs(&mut head) } != 0 {
-        return out;
-    }
-
-    let mut cursor = head;
-    while !cursor.is_null() {
-        // SAFETY: `cursor` is non-null here and points at a node of the list
-        // `getifaddrs` allocated, which stays valid until `freeifaddrs` below.
-        let entry = unsafe { &*cursor };
-        cursor = entry.ifa_next;
-
-        if entry.ifa_addr.is_null() {
-            continue;
-        }
-        let flags = entry.ifa_flags as i32;
-        let up = flags & libc::IFF_UP != 0 && flags & libc::IFF_RUNNING != 0;
-        if !up || flags & libc::IFF_LOOPBACK != 0 {
-            continue;
-        }
-        if let Some(ip) = sockaddr_ip(entry.ifa_addr) {
-            out.insert(ip);
-        }
-    }
-
-    // SAFETY: `head` is the list `getifaddrs` allocated above, freed once, and
-    // not read after this point (`cursor` is null by loop exit).
-    unsafe { libc::freeifaddrs(head) };
-    out
-}
-
-/// No portable interface enumeration without `getifaddrs`. The fingerprint
-/// degrades to the source-address probe, which still catches every
-/// default-route move; the native `NotifyIpInterfaceChange` backend is the
-/// answer here rather than a richer poll.
-#[cfg(not(unix))]
-fn interface_addrs() -> BTreeSet<IpAddr> {
-    BTreeSet::new()
-}
-
-/// Read an `IpAddr` out of a kernel-supplied `sockaddr`, if it is one of the
-/// two families we fingerprint.
-#[cfg(unix)]
-fn sockaddr_ip(sa: *const libc::sockaddr) -> Option<IpAddr> {
-    // SAFETY: `sa` is non-null (checked by the caller) and points at a
-    // kernel-supplied `sockaddr` whose `sa_family` selects the concrete layout
-    // that follows. Both branches copy out through `read_unaligned`, so nothing
-    // here assumes the pointer is aligned for the larger type.
-    let family = unsafe { std::ptr::addr_of!((*sa).sa_family).read_unaligned() } as i32;
-    match family {
-        libc::AF_INET => {
-            // SAFETY: family is AF_INET, so the allocation is at least a
-            // `sockaddr_in`.
-            let raw: libc::sockaddr_in = unsafe { std::ptr::read_unaligned(sa.cast()) };
-            // `s_addr` holds the octets in network order, so its native-endian
-            // bytes are the address octets in order.
-            Some(IpAddr::V4(Ipv4Addr::from(
-                raw.sin_addr.s_addr.to_ne_bytes(),
-            )))
-        }
-        libc::AF_INET6 => {
-            // SAFETY: family is AF_INET6, so the allocation is at least a
-            // `sockaddr_in6`.
-            let raw: libc::sockaddr_in6 = unsafe { std::ptr::read_unaligned(sa.cast()) };
-            Some(IpAddr::V6(Ipv6Addr::from(raw.sin6_addr.s6_addr)))
-        }
-        _ => None,
-    }
 }
 
 #[cfg(test)]

--- a/src/node/netmon/mod.rs
+++ b/src/node/netmon/mod.rs
@@ -227,7 +227,7 @@ impl NetFingerprint {
                     (
                         t.peer,
                         PeerPath {
-                            current: preferred_source(t.dest),
+                            current: preferred_source(t.dest, t.bind),
                             bound: t.bound,
                         },
                     )
@@ -350,6 +350,18 @@ pub(in crate::node) struct ProbeTarget {
     pub dest: SocketAddr,
     /// The local address its connected UDP socket is bound to, if it has one.
     pub bound: Option<IpAddr>,
+    /// The address to bind the probe to, when the peer's transport binds a
+    /// specific one rather than the wildcard. `None` means bind unspecified
+    /// and let the kernel choose, which is the default posture.
+    ///
+    /// This exists so the probe asks the same question the send path answers.
+    /// `open_connected_fd` binds the transport's configured address verbatim
+    /// and only then connects, so under a non-wildcard `transports.udp.bind_addr`
+    /// the socket's source is that address whatever the routing table says. An
+    /// unconstrained probe would answer with the kernel's choice instead, and
+    /// the two would disagree permanently — reporting a first-sight move, on
+    /// every peer, forever, with nothing having moved.
+    pub bind: Option<IpAddr>,
 }
 
 /// One peer whose local source address changed between two samples.
@@ -617,6 +629,7 @@ pub(in crate::node) fn probe_targets(snapshot: &EntitySnapshot) -> Vec<ProbeTarg
                 peer: row.node_addr,
                 dest,
                 bound: row.bound_source,
+                bind: row.probe_bind,
             })
         })
         .collect()
@@ -766,7 +779,8 @@ where
     }
 }
 
-/// The source address the kernel would use to reach `probe`.
+/// The source address the kernel would use to reach `probe`, from `bind_to` if
+/// the transport constrains it.
 ///
 /// `connect(2)` on a UDP socket is a pure routing-table operation: it resolves
 /// the route, binds a source address, and sends nothing. The socket is dropped
@@ -777,10 +791,18 @@ where
 /// itself a fingerprint value, reported as `None` rather than swallowed. It is
 /// the state a stranded peer is in, so losing it would blind the detector to
 /// the case it most needs to see.
-fn preferred_source(probe: SocketAddr) -> Option<IpAddr> {
-    let bind: SocketAddr = match probe {
-        SocketAddr::V4(_) => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
-        SocketAddr::V6(_) => SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
+fn preferred_source(probe: SocketAddr, bind_to: Option<IpAddr>) -> Option<IpAddr> {
+    // Port 0 always: the probe wants the transport's *address* constraint, not
+    // its port, and binding the live port would collide with the socket the
+    // transport already holds there. A family mismatch between the configured
+    // bind and this peer is not an error to report — the transport could not
+    // have reached the peer from it either — so fall back to unspecified and
+    // let the connect below fail on its own terms.
+    let bind: SocketAddr = match (probe, bind_to) {
+        (SocketAddr::V4(_), Some(ip @ IpAddr::V4(_))) => SocketAddr::new(ip, 0),
+        (SocketAddr::V6(_), Some(ip @ IpAddr::V6(_))) => SocketAddr::new(ip, 0),
+        (SocketAddr::V4(_), _) => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+        (SocketAddr::V6(_), _) => SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
     };
     let socket = UdpSocket::bind(bind).ok()?;
     socket.connect(probe).ok()?;

--- a/src/node/netmon/mod.rs
+++ b/src/node/netmon/mod.rs
@@ -526,6 +526,17 @@ impl WakeSource {
         timer
     }
 
+    /// The netlink groups this wake source is subscribed to, or `None` if it
+    /// is not a live netlink source. For the group-mask assertion in the
+    /// tests — see `the_detector_subscribes_to_the_route_groups_not_just_link`.
+    #[cfg(all(test, any(target_os = "linux", target_os = "android")))]
+    fn subscribed_groups(&self) -> Option<u32> {
+        match &self.source {
+            Wake::Kernel(watcher) => watcher.subscribed_groups(),
+            _ => None,
+        }
+    }
+
     /// Wait until it is worth sampling again.
     async fn wait(&mut self) {
         let WakeSource { source, timer } = self;

--- a/src/node/netmon/mod.rs
+++ b/src/node/netmon/mod.rs
@@ -126,6 +126,17 @@
 //! answering entirely — the route to it is gone — is a move to "no source
 //! address" and does count, because that peer is exactly the one now stranded.
 //!
+//! A peer seen for the *first* time is the one case the intersection cannot
+//! decide, and it cannot simply be skipped: the sample in which a peer first
+//! appears may already be the post-change one, and adopting it silently would
+//! swallow the event while that peer's socket stayed pinned to the path the
+//! host has just left. Such a peer is judged against its own send path
+//! instead — the source `connect(2)` pinned its socket to, which needs no
+//! history and asks directly whether that socket is already stale. Churn still
+//! fires nothing on its own, because a peer joining onto a path that has not
+//! moved is pinned exactly where its traffic goes. See
+//! [`NetFingerprint::moved`] for the residual this leaves.
+//!
 use std::collections::BTreeMap;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
@@ -171,17 +182,32 @@ pub(crate) type NetChangeTx = mpsc::Sender<NetChange>;
 /// Where this host sits relative to the peers it holds: one local source
 /// address per peer, as the routing table would choose it right now.
 ///
-/// The contents are compared over the intersection of two samples' peer sets —
-/// see [`NetFingerprint::moved`], which is the whole definition of "the medium
-/// changed" and the only thing the detector asks of a sample.
+/// Each peer carries both the answer to that question and the source its
+/// connected socket is already pinned to, because a peer seen for the first
+/// time has no earlier sample to be compared against and is judged against its
+/// own socket instead. [`NetFingerprint::moved`] is the whole definition of
+/// "the medium changed" and the only thing the detector asks of a sample.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct NetFingerprint {
-    /// Peer → the local address the kernel would send to it from. A peer whose
-    /// route lookup fails maps to `None`, which is a distinct and meaningful
-    /// value rather than an absent key: the peer is still ours, and having no
-    /// route to it is precisely the state worth reacting to. A peer with no
-    /// probeable address never appears at all.
-    sources: BTreeMap<NodeAddr, Option<IpAddr>>,
+    /// Peer → where its traffic leaves from. A peer with no probeable address
+    /// never appears at all.
+    sources: BTreeMap<NodeAddr, PeerPath>,
+}
+
+/// One peer's local end, from two directions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PeerPath {
+    /// The local address the kernel would choose to reach this peer right now.
+    /// `None` when the route lookup fails, which is a real value rather than a
+    /// missing one: the peer is still ours, and having no route to it is
+    /// precisely the state worth reacting to.
+    current: Option<IpAddr>,
+    /// The local address this peer's connected UDP socket is bound to, if it
+    /// has one. Unlike `current` this is not a question put to the kernel — it
+    /// is what the send path is already doing, and it is the only thing that
+    /// gives a peer the detector has not seen before a baseline to be judged
+    /// against. See [`NetFingerprint::moved`].
+    bound: Option<IpAddr>,
 }
 
 impl NetFingerprint {
@@ -193,49 +219,137 @@ impl NetFingerprint {
     /// `node.limits.max_peers`, so a full table is a few hundred syscalls on a
     /// multi-second timer; it runs inline in the detector's task rather than
     /// through `spawn_blocking`.
-    pub(crate) fn sample(targets: &[(NodeAddr, SocketAddr)]) -> Self {
+    pub(in crate::node) fn sample(targets: &[ProbeTarget]) -> Self {
         Self {
             sources: targets
                 .iter()
-                .map(|(peer, dest)| (*peer, preferred_source(*dest)))
+                .map(|t| {
+                    (
+                        t.peer,
+                        PeerPath {
+                            current: preferred_source(t.dest),
+                            bound: t.bound,
+                        },
+                    )
+                })
                 .collect(),
         }
     }
 
     /// Build a fingerprint directly, so a test can script a sequence of
-    /// samples instead of probing real peers.
+    /// samples instead of probing real peers. No peer has a connected socket;
+    /// [`Self::for_test_bound`] is the variant that gives one.
     #[cfg(test)]
     pub(crate) fn for_test(sources: &[(NodeAddr, Option<IpAddr>)]) -> Self {
         Self {
-            sources: sources.iter().copied().collect(),
+            sources: sources
+                .iter()
+                .map(|(peer, current)| {
+                    (
+                        *peer,
+                        PeerPath {
+                            current: *current,
+                            bound: None,
+                        },
+                    )
+                })
+                .collect(),
         }
     }
 
-    /// Which peers held by *both* samples are now reached from a different
-    /// local address.
+    /// As [`Self::for_test`], with each peer's connected socket bound where the
+    /// third element says.
+    #[cfg(test)]
+    pub(crate) fn for_test_bound(sources: &[(NodeAddr, Option<IpAddr>, Option<IpAddr>)]) -> Self {
+        Self {
+            sources: sources
+                .iter()
+                .map(|(peer, current, bound)| {
+                    (
+                        *peer,
+                        PeerPath {
+                            current: *current,
+                            bound: *bound,
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    /// Which peers are now leaving from somewhere other than where their
+    /// traffic is actually going out.
     ///
-    /// The intersection is the point. A peer that has only just been
-    /// authenticated, or one that has just been reaped, differs between the two
-    /// samples for reasons that have nothing to do with the host's attachment,
-    /// and the reaction — drop every connected socket, heartbeat every peer —
-    /// is far too blunt to fire on ordinary peer churn. So a key missing from
-    /// either side is skipped, and only a peer observed twice can report
-    /// anything.
+    /// Two rules, because there are two ways to know:
+    ///
+    /// **A peer in both samples** is judged on whether its probe answer moved.
+    /// The comparison is over the *intersection* of the two peer sets, never
+    /// the union: a peer that has only just been authenticated, or one that has
+    /// just been reaped, differs between the samples for reasons that have
+    /// nothing to do with the host's attachment, and the reaction — drop every
+    /// connected socket, heartbeat every peer — is far too blunt to fire on
+    /// ordinary peer churn.
+    ///
+    /// **A peer only in the newer sample** has no previous probe answer to be
+    /// compared against, and skipping it outright leaves a hole this detector
+    /// cannot afford. `last` gains a peer only at the first wake *after* it
+    /// appears, so a medium change in that window is the detector's first
+    /// sight of that peer, and adopting it silently would swallow the very
+    /// event being adopted — while the peer's connected socket stays pinned to
+    /// the path the host has just left. The window is up to one
+    /// `poll_interval_secs` after every peer that authenticates, and a medium
+    /// change wakes the detector, so the two coincide readily rather than
+    /// rarely.
+    ///
+    /// So such a peer is judged against `bound` instead: the address its
+    /// connected socket is *actually* using. That needs no history — it asks
+    /// whether the send path is already stale, which is the question the whole
+    /// subsystem exists to answer, and it is exactly the peer that would
+    /// otherwise be left stranded. Churn still cannot fire anything on its own:
+    /// a peer joining onto a path that has not moved has `bound == current` and
+    /// reports nothing.
+    ///
+    /// A new peer with no connected socket (`bound` is `None`) is still
+    /// skipped, and is the residual. It is a much smaller one: with no socket
+    /// there is no pinning to repair, since the wildcard socket resolves a
+    /// route per packet, so the peer is not stranded. It costs only the
+    /// immediate heartbeat that would have told the far side to re-pin, leaving
+    /// it to notice at the next `heartbeat_interval_secs`.
     ///
     /// An empty result means nothing moved; it is the detector's entire
     /// definition of "no change".
     fn moved(&self, next: &Self) -> Vec<PeerSourceMove> {
-        self.sources
+        next.sources
             .iter()
-            .filter_map(|(peer, before)| next.sources.get(peer).map(|after| (peer, before, after)))
-            .filter(|(_, before, after)| before != after)
-            .map(|(peer, before, after)| PeerSourceMove {
-                peer: *peer,
-                before: *before,
-                after: *after,
+            .filter_map(|(peer, now)| {
+                let before = match self.sources.get(peer) {
+                    // Seen before: its own previous probe answer.
+                    Some(then) => then.current,
+                    // First sight: what its socket is bound to, if it has one.
+                    None => match now.bound {
+                        Some(bound) => Some(bound),
+                        None => return None,
+                    },
+                };
+                (before != now.current).then_some(PeerSourceMove {
+                    peer: *peer,
+                    before,
+                    after: now.current,
+                })
             })
             .collect()
     }
+}
+
+/// One peer to probe: where to aim, and what its send path is already using.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::node) struct ProbeTarget {
+    /// The peer this is about.
+    pub peer: NodeAddr,
+    /// Its transport address — the destination the route lookup is run for.
+    pub dest: SocketAddr,
+    /// The local address its connected UDP socket is bound to, if it has one.
+    pub bound: Option<IpAddr>,
 }
 
 /// One peer whose local source address changed between two samples.
@@ -483,11 +597,17 @@ pub(crate) fn spawn_detector(
 /// a MAC, a `.onion`, a Nym recipient and an unresolved hostname all arrive
 /// here as `None` and are skipped, with no per-transport special-casing in
 /// this module.
-pub(in crate::node) fn probe_targets(snapshot: &EntitySnapshot) -> Vec<(NodeAddr, SocketAddr)> {
+pub(in crate::node) fn probe_targets(snapshot: &EntitySnapshot) -> Vec<ProbeTarget> {
     snapshot
         .peers
         .iter()
-        .filter_map(|row| row.probe_target.map(|dest| (row.node_addr, dest)))
+        .filter_map(|row| {
+            row.probe_target.map(|dest| ProbeTarget {
+                peer: row.node_addr,
+                dest,
+                bound: row.bound_source,
+            })
+        })
         .collect()
 }
 

--- a/src/node/netmon/mod.rs
+++ b/src/node/netmon/mod.rs
@@ -437,10 +437,9 @@ pub(crate) struct NetChange {
 }
 
 impl NetChange {
-    /// A synthetic change, for tests that exercise the node's *reaction* to a
-    /// medium change rather than its detection. The summary is empty because
-    /// the handler does not read it — it re-evaluates every peer regardless of
-    /// which peer's source address moved.
+    /// A synthetic change naming no peers, for tests that assert the node does
+    /// *nothing* — the reaction is scoped to the peers the summary names, so an
+    /// empty summary must move nothing.
     #[cfg(test)]
     pub(crate) fn for_test(generation: u64) -> Self {
         Self {
@@ -448,6 +447,30 @@ impl NetChange {
             summary: NetChangeSummary {
                 moved: Vec::new(),
                 probed: 0,
+            },
+        }
+    }
+
+    /// A synthetic change naming `peers` as having moved, for tests that
+    /// exercise the node's *reaction* rather than its detection.
+    ///
+    /// The addresses are placeholders: the handler reads only which peers
+    /// moved, not where from or to.
+    #[cfg(test)]
+    pub(crate) fn for_test_moved(generation: u64, peers: &[NodeAddr]) -> Self {
+        let moved: Vec<PeerSourceMove> = peers
+            .iter()
+            .map(|peer| PeerSourceMove {
+                peer: *peer,
+                before: Some(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10))),
+                after: Some(IpAddr::V4(Ipv4Addr::new(10, 40, 0, 7))),
+            })
+            .collect();
+        Self {
+            generation,
+            summary: NetChangeSummary {
+                probed: moved.len(),
+                moved,
             },
         }
     }

--- a/src/node/netmon/mod.rs
+++ b/src/node/netmon/mod.rs
@@ -159,7 +159,7 @@ use crate::identity::NodeAddr;
 /// change again; riding it out coalesces the burst into one event. Bounded so
 /// an interface that flaps continuously still produces events rather than
 /// starving the handler forever.
-const MAX_DEBOUNCE_ROUNDS: u32 = 8;
+pub(crate) const MAX_DEBOUNCE_ROUNDS: u32 = 8;
 
 /// Minimum spacing between two reported changes.
 ///

--- a/src/node/netmon/tests.rs
+++ b/src/node/netmon/tests.rs
@@ -760,6 +760,8 @@ async fn an_interface_no_peer_is_reached_through_does_not_move_the_fingerprint()
     // namespace, so the routes the netlink test above installs are still there
     // and a shared prefix collides with EEXIST depending on the order they run.
     const NET: Ipv4Addr = Ipv4Addr::new(198, 51, 100, 0);
+    const CARRIER: Ipv4Addr = Ipv4Addr::new(10, 99, 0, 1);
+    const BRIDGE: Ipv4Addr = Ipv4Addr::new(172, 30, 0, 1);
     const DEST: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1)), 9);
 
     /// Bring up a dummy interface carrying `addr/24`, returning its index.
@@ -801,7 +803,7 @@ async fn an_interface_no_peer_is_reached_through_does_not_move_the_fingerprint()
 
     // The medium the peer is actually reached over: an interface plus the
     // default route out of it.
-    let carrier = dummy_up(&handle, "mc-carrier", Ipv4Addr::new(10, 99, 0, 1)).await;
+    let carrier = dummy_up(&handle, "mc-carrier", CARRIER).await;
     handle
         .route()
         .add(
@@ -818,7 +820,7 @@ async fn an_interface_no_peer_is_reached_through_does_not_move_the_fingerprint()
     let before = NetFingerprint::sample(&targets);
     assert_eq!(
         before.sources.get(&peer(1)).map(|p| p.current),
-        Some(Some(IpAddr::V4(Ipv4Addr::new(10, 99, 0, 1)))),
+        Some(Some(IpAddr::V4(CARRIER))),
         "the peer must be reached over the carrier before anything else appears, \
          or this test proves nothing about what happens next"
     );
@@ -827,7 +829,7 @@ async fn an_interface_no_peer_is_reached_through_does_not_move_the_fingerprint()
     // what `docker compose up` leaves behind. It is up, it is not loopback, and
     // it carries an address — every property the old host-wide set keyed on —
     // but no peer is reached through it.
-    dummy_up(&handle, "mc-bridge", Ipv4Addr::new(172, 30, 0, 1)).await;
+    dummy_up(&handle, "mc-bridge", BRIDGE).await;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let after = NetFingerprint::sample(&targets);
@@ -835,6 +837,39 @@ async fn an_interface_no_peer_is_reached_through_does_not_move_the_fingerprint()
         before.moved(&after),
         Vec::new(),
         "an interface carrying no route to any peer must not be a medium change"
+    );
+
+    // While two addresses exist here, measure the reason the probe carries a
+    // bind constraint at all.
+    //
+    // `open_connected_fd` binds the transport's configured address verbatim
+    // and only then connects, so under a non-wildcard `transports.udp.bind_addr`
+    // the socket's source is that address whatever the routing table says. An
+    // unconstrained probe answers with the kernel's choice instead. Where the
+    // two differ, the first-sight rule would compare them and report a move on
+    // every peer, permanently, with nothing having moved.
+    //
+    // The interloper's address is reachable-from but is not what the route to
+    // DEST would pick, so it is exactly that disagreement, made concrete: the
+    // unconstrained probe answers with the carrier, the constrained one with
+    // what it was told to bind.
+    let unconstrained = preferred_source(DEST, None);
+    let constrained = preferred_source(DEST, Some(IpAddr::V4(BRIDGE)));
+    assert_eq!(
+        unconstrained,
+        Some(IpAddr::V4(CARRIER)),
+        "an unconstrained probe follows the route"
+    );
+    assert_eq!(
+        constrained,
+        Some(IpAddr::V4(BRIDGE)),
+        "a constrained probe answers from the address it was told to bind, which \
+         is what a non-wildcard bind_addr makes the send path do"
+    );
+    assert_ne!(
+        unconstrained, constrained,
+        "if these agreed the constraint would be untested, and the phantom-move \
+         case it exists for could not arise"
     );
 
     // The other half, in the same namespace and against the same live sampler:

--- a/src/node/netmon/tests.rs
+++ b/src/node/netmon/tests.rs
@@ -378,6 +378,7 @@ fn target(p: NodeAddr, dest: SocketAddr) -> ProbeTarget {
         peer: p,
         dest,
         bound: None,
+        bind: None,
     }
 }
 

--- a/src/node/netmon/tests.rs
+++ b/src/node/netmon/tests.rs
@@ -181,6 +181,72 @@ async fn a_peer_that_joins_is_compared_on_the_sample_after() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn a_move_in_the_window_after_a_peer_joins_is_still_reported() {
+    // The hole the intersection rule opens on its own, and the reason a peer
+    // seen for the first time is judged against its socket rather than skipped.
+    //
+    // `last` gains a peer only at the first wake after it appears, so a medium
+    // change inside that window is the detector's *first* sight of that peer:
+    // there is no earlier probe answer to compare against, the intersection is
+    // empty, and adopting the sample silently swallows the very event being
+    // adopted. Meanwhile the peer's connected socket is still pinned to the
+    // path the host has just left, and nothing else will repair it — the
+    // outage runs to `link_dead_timeout_secs`.
+    //
+    // The window is up to one poll interval after every peer that
+    // authenticates, and a medium change is itself what wakes the detector, so
+    // the two coincide readily. Its socket is bound on the old path while the
+    // probe already answers with the new one, and that disagreement is the
+    // report.
+    let empty = NetFingerprint::for_test(&[]);
+    let joined_after_the_move = NetFingerprint::for_test_bound(&[(
+        peer(1),
+        Some(v4(10, 40, 0, 7)),
+        Some(v4(192, 168, 1, 10)),
+    )]);
+    let (sampler, _) = scripted(vec![empty, joined_after_the_move]);
+    let (tx, mut rx) = mpsc::channel(1);
+
+    tokio::spawn(run_detector(tx, cfg(1, 0), sampler, timer_wake(1)));
+
+    let change = expect_change(&mut rx).await;
+    assert_eq!(
+        change.summary.moved,
+        vec![PeerSourceMove {
+            peer: peer(1),
+            before: Some(v4(192, 168, 1, 10)),
+            after: Some(v4(10, 40, 0, 7)),
+        }],
+        "a peer whose socket is bound off the current path must be reported on \
+         first sight, not adopted"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_peer_joining_onto_a_settled_path_is_still_not_a_change() {
+    // The other side of that rule: judging a first-seen peer against its socket
+    // must not turn ordinary peer churn into a medium change. A peer that
+    // authenticates while nothing is moving has its socket bound exactly where
+    // the probe says its traffic goes, so there is nothing to report.
+    let empty = NetFingerprint::for_test(&[]);
+    let joined = NetFingerprint::for_test_bound(&[(
+        peer(1),
+        Some(v4(192, 168, 1, 10)),
+        Some(v4(192, 168, 1, 10)),
+    )]);
+    let (sampler, _) = scripted(vec![empty, joined]);
+    let (tx, mut rx) = mpsc::channel(1);
+
+    tokio::spawn(run_detector(tx, cfg(1, 0), sampler, timer_wake(1)));
+
+    expect_quiet(
+        &mut rx,
+        "a peer joining onto a path that has not moved is not a medium change",
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
 async fn churn_during_a_handover_does_not_mask_the_handover() {
     // Both at once: a peer leaves while the medium moves under the peer that
     // stays. The intersection rule must ignore the departure and still report
@@ -306,12 +372,21 @@ async fn a_node_with_no_peers_reports_nothing() {
 /// accident. Nothing is ever sent to it.
 const OFF_LINK: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)), 9);
 
+/// A probe target for `peer`, with no connected socket behind it.
+fn target(p: NodeAddr, dest: SocketAddr) -> ProbeTarget {
+    ProbeTarget {
+        peer: p,
+        dest,
+        bound: None,
+    }
+}
+
 #[test]
 fn sampling_the_live_host_is_self_consistent() {
     // Two samples taken back to back on an idle host describe the same
     // attachment. This is the property the whole detector rests on: if plain
     // sampling were noisy, every poll would look like a medium change.
-    let targets = [(peer(1), OFF_LINK)];
+    let targets = [target(peer(1), OFF_LINK)];
     let first = NetFingerprint::sample(&targets);
     let second = NetFingerprint::sample(&targets);
     assert_eq!(
@@ -331,7 +406,7 @@ fn every_target_is_recorded_whether_or_not_it_has_a_route() {
     // indistinguishable from "this peer was reaped", and the intersection rule
     // would then discard exactly the event the detector exists to catch. The
     // assertion holds on a CI container with no route at all.
-    let targets = [(peer(1), OFF_LINK), (peer(2), OFF_LINK)];
+    let targets = [target(peer(1), OFF_LINK), target(peer(2), OFF_LINK)];
     let sample = NetFingerprint::sample(&targets);
     assert_eq!(sample.sources.len(), 2);
     assert!(sample.sources.contains_key(&peer(1)));
@@ -343,8 +418,8 @@ fn a_probe_never_yields_a_loopback_or_unspecified_source() {
     // Either of those would be the kernel declining to choose, not an answer,
     // and treating one as an address would make the fingerprint move whenever
     // the route lookup failed differently.
-    let sample = NetFingerprint::sample(&[(peer(1), OFF_LINK)]);
-    if let Some(Some(ip)) = sample.sources.get(&peer(1)) {
+    let sample = NetFingerprint::sample(&[target(peer(1), OFF_LINK)]);
+    if let Some(Some(ip)) = sample.sources.get(&peer(1)).map(|p| p.current) {
         assert!(!ip.is_loopback(), "loopback source for an off-link probe");
         assert!(
             !ip.is_unspecified(),
@@ -709,11 +784,11 @@ async fn an_interface_no_peer_is_reached_through_does_not_move_the_fingerprint()
         .expect("adding a default route");
     tokio::time::sleep(Duration::from_millis(200)).await;
 
-    let targets = [(peer(1), DEST)];
+    let targets = [target(peer(1), DEST)];
     let before = NetFingerprint::sample(&targets);
     assert_eq!(
-        before.sources.get(&peer(1)),
-        Some(&Some(IpAddr::V4(Ipv4Addr::new(10, 99, 0, 1)))),
+        before.sources.get(&peer(1)).map(|p| p.current),
+        Some(Some(IpAddr::V4(Ipv4Addr::new(10, 99, 0, 1)))),
         "the peer must be reached over the carrier before anything else appears, \
          or this test proves nothing about what happens next"
     );
@@ -773,5 +848,199 @@ async fn an_interface_no_peer_is_reached_through_does_not_move_the_fingerprint()
             after: Some(IpAddr::V4(Ipv4Addr::new(172, 30, 0, 1))),
         }],
         "the route to the peer moving is exactly what must be reported"
+    );
+}
+
+/// An interface going down and coming back up, which the docker suite does not
+/// cover: it moves the default route with both interfaces held up throughout,
+/// deliberately, so that it tests a medium change rather than a link failure.
+/// This is the other shape — the interface carrying a peer is taken away and
+/// given back.
+///
+/// Three transitions, and the third is the one worth having. Downing the
+/// interface a peer is reached over must report; bringing it back must report;
+/// downing an interface no peer is reached over must not. That last case is the
+/// down-direction counterpart of the container test above, and it is the one a
+/// link-state watcher gets wrong — the kernel emits exactly the same link event
+/// for all three.
+///
+/// Routes here are specific to this test's own prefix rather than defaults, so
+/// it shares the `unshare -rn` namespace with the tests above without fighting
+/// them over the default route.
+///
+/// ```text
+/// unshare -rn cargo test --lib netmon -- --ignored --nocapture
+/// ```
+#[cfg(target_os = "linux")]
+#[tokio::test]
+#[ignore = "needs CAP_NET_ADMIN in a private netns; run under `unshare -rn`"]
+async fn an_interface_going_down_is_reported_only_when_a_peer_was_reached_over_it() {
+    use futures::TryStreamExt;
+    use std::net::Ipv4Addr;
+
+    // RFC 5737 TEST-NET-3, so this test's routes cannot collide with either of
+    // the two above in the shared namespace.
+    const NET: Ipv4Addr = Ipv4Addr::new(203, 0, 113, 0);
+    const DEST: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1)), 9);
+    const PRIMARY: Ipv4Addr = Ipv4Addr::new(10, 77, 0, 1);
+    const BACKUP: Ipv4Addr = Ipv4Addr::new(10, 78, 0, 1);
+    const IDLE: Ipv4Addr = Ipv4Addr::new(10, 79, 0, 1);
+
+    let (connection, handle, _) = rtnetlink::new_connection().expect("netlink connection");
+    tokio::spawn(connection);
+
+    async fn index_of(handle: &rtnetlink::Handle, name: &str) -> u32 {
+        handle
+            .link()
+            .get()
+            .match_name(name.to_string())
+            .execute()
+            .try_next()
+            .await
+            .expect("link query")
+            .expect("the link exists")
+            .header
+            .index
+    }
+
+    async fn dummy_up(handle: &rtnetlink::Handle, name: &str, addr: Ipv4Addr) -> u32 {
+        handle
+            .link()
+            .add(rtnetlink::LinkDummy::new(name).build())
+            .execute()
+            .await
+            .expect("creating a dummy link needs CAP_NET_ADMIN in this namespace");
+        let index = index_of(handle, name).await;
+        handle
+            .address()
+            .add(index, std::net::IpAddr::V4(addr), 24)
+            .execute()
+            .await
+            .expect("adding an address");
+        handle
+            .link()
+            .set(rtnetlink::LinkUnspec::new_with_index(index).up().build())
+            .execute()
+            .await
+            .expect("bringing the link up");
+        index
+    }
+
+    async fn set_link(handle: &rtnetlink::Handle, index: u32, up: bool) {
+        let msg = if up {
+            rtnetlink::LinkUnspec::new_with_index(index).up().build()
+        } else {
+            rtnetlink::LinkUnspec::new_with_index(index).down().build()
+        };
+        handle
+            .link()
+            .set(msg)
+            .execute()
+            .await
+            .expect("changing link state");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    async fn route_to_peer(handle: &rtnetlink::Handle, index: u32, metric: u32) {
+        handle
+            .route()
+            .add(
+                rtnetlink::RouteMessageBuilder::<Ipv4Addr>::new()
+                    .destination_prefix(NET, 24)
+                    .output_interface(index)
+                    .priority(metric)
+                    .build(),
+            )
+            .execute()
+            .await
+            .expect("adding a route to the peer");
+    }
+
+    // Two paths to the peer, primary preferred, plus an interface carrying no
+    // route to it at all.
+    let primary = dummy_up(&handle, "mc-updn-a", PRIMARY).await;
+    let backup = dummy_up(&handle, "mc-updn-b", BACKUP).await;
+    let idle = dummy_up(&handle, "mc-updn-c", IDLE).await;
+    route_to_peer(&handle, primary, 100).await;
+    route_to_peer(&handle, backup, 200).await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let targets = [target(peer(1), DEST)];
+    let on_primary = NetFingerprint::sample(&targets);
+    assert_eq!(
+        on_primary.sources.get(&peer(1)).map(|p| p.current),
+        Some(Some(IpAddr::V4(PRIMARY))),
+        "the peer must start out on the primary, or nothing below means anything"
+    );
+
+    // 1. The interface the peer is reached over goes down. The route with it,
+    //    so the kernel falls back to the higher-metric path.
+    set_link(&handle, primary, false).await;
+    let on_backup = NetFingerprint::sample(&targets);
+    assert_eq!(
+        on_primary.moved(&on_backup),
+        vec![PeerSourceMove {
+            peer: peer(1),
+            before: Some(IpAddr::V4(PRIMARY)),
+            after: Some(IpAddr::V4(BACKUP)),
+        }],
+        "losing the interface a peer was reached over is a medium change"
+    );
+
+    // 2. And back. Not symmetric with the above: this direction returns to an
+    //    interface that has been holding a stale address throughout.
+    //
+    //    The route has to be re-added by hand, because the kernel deleted it
+    //    when the link went down and does not restore it when the link returns
+    //    — verified in a namespace, not assumed. On a real host that re-add is
+    //    what the DHCP client or the network manager does on carrier-up, so
+    //    re-adding it here is modelling the real sequence rather than working
+    //    around it. The address, by contrast, does survive, which is exactly
+    //    the trap the detector exists for: the interface is up and addressed
+    //    again the instant the link returns, and only the route says whether
+    //    anything is reached over it.
+    set_link(&handle, primary, true).await;
+    route_to_peer(&handle, primary, 100).await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let back_on_primary = NetFingerprint::sample(&targets);
+    assert_eq!(
+        on_backup.moved(&back_on_primary),
+        vec![PeerSourceMove {
+            peer: peer(1),
+            before: Some(IpAddr::V4(BACKUP)),
+            after: Some(IpAddr::V4(PRIMARY)),
+        }],
+        "the interface returning and reclaiming the route is a medium change too"
+    );
+
+    // 3. An interface no peer is reached over goes down. Same kernel link
+    //    event as case 1, and it must report nothing.
+    set_link(&handle, idle, false).await;
+    assert_eq!(
+        back_on_primary.moved(&NetFingerprint::sample(&targets)),
+        Vec::new(),
+        "an interface no peer was reached over going down is not a medium change"
+    );
+
+    // 4. Every path this test installed goes away at once. Where the peer
+    //    lands afterwards is deliberately not asserted: it depends on what
+    //    else the host offers, and in this shared namespace it falls back to
+    //    the default route another `--ignored` test installed. What must hold
+    //    either way is that the peer moved off the primary and that the move
+    //    is reported — a peer resolving to nothing at all is pinned by
+    //    `every_target_is_recorded_whether_or_not_it_has_a_route`, which runs
+    //    on a CI container with no route to fall back to.
+    set_link(&handle, primary, false).await;
+    set_link(&handle, backup, false).await;
+    let stranded = NetFingerprint::sample(&targets);
+    assert_ne!(
+        stranded.sources.get(&peer(1)).map(|p| p.current),
+        Some(Some(IpAddr::V4(PRIMARY))),
+        "the peer cannot still be reached over an interface that is down"
+    );
+    assert_eq!(
+        back_on_primary.moved(&stranded).len(),
+        1,
+        "losing every path this test installed is a medium change"
     );
 }

--- a/src/node/netmon/tests.rs
+++ b/src/node/netmon/tests.rs
@@ -35,6 +35,19 @@ fn v4(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
     IpAddr::V4(Ipv4Addr::new(a, b, c, d))
 }
 
+/// A distinct peer address. Only identity matters here, so the byte pattern is
+/// arbitrary as long as two peers differ.
+fn peer(n: u8) -> NodeAddr {
+    NodeAddr::from_bytes([n; 16])
+}
+
+/// A fingerprint in which `peers` are all reached from `source`. The common
+/// shape: every peering rides one medium, so they move together.
+fn all_from(peers: &[NodeAddr], source: Option<IpAddr>) -> NetFingerprint {
+    let sources: Vec<_> = peers.iter().map(|p| (*p, source)).collect();
+    NetFingerprint::for_test(&sources)
+}
+
 /// A timer-only wake source at the config's poll period — the portable
 /// backend's behaviour, and the baseline the netlink tests compare against.
 fn timer_wake(poll_secs: u64) -> WakeSource {
@@ -62,7 +75,7 @@ fn scripted(samples: Vec<NetFingerprint>) -> (impl Fn() -> NetFingerprint, Arc<A
 
 #[tokio::test(start_paused = true)]
 async fn steady_attachment_reports_nothing() {
-    let steady = NetFingerprint::for_test(Some(v4(192, 168, 1, 10)), &[v4(192, 168, 1, 10)]);
+    let steady = all_from(&[peer(1), peer(2)], Some(v4(192, 168, 1, 10)));
     let (sampler, _) = scripted(vec![steady]);
     let (tx, mut rx) = mpsc::channel(1);
 
@@ -72,11 +85,11 @@ async fn steady_attachment_reports_nothing() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn a_default_route_move_is_reported() {
-    // The WLAN → 5G shape: the interface set changes and the preferred source
-    // address moves with it.
-    let wlan = NetFingerprint::for_test(Some(v4(192, 168, 1, 10)), &[v4(192, 168, 1, 10)]);
-    let cell = NetFingerprint::for_test(Some(v4(10, 40, 0, 7)), &[v4(10, 40, 0, 7)]);
+async fn a_medium_change_under_a_peer_is_reported() {
+    // The WLAN → 5G shape: the local address the kernel would reach the peer
+    // from moves, which is the whole signal.
+    let wlan = all_from(&[peer(1)], Some(v4(192, 168, 1, 10)));
+    let cell = all_from(&[peer(1)], Some(v4(10, 40, 0, 7)));
     let (sampler, _) = scripted(vec![wlan, cell]);
     let (tx, mut rx) = mpsc::channel(1);
 
@@ -84,22 +97,115 @@ async fn a_default_route_move_is_reported() {
 
     let change = expect_change(&mut rx).await;
     assert_eq!(change.generation, 1);
-    assert!(change.summary.v4_source_moved);
-    assert_eq!(change.summary.v4_source, Some(v4(10, 40, 0, 7)));
-    assert_eq!(change.summary.added, vec![v4(10, 40, 0, 7)]);
-    assert_eq!(change.summary.removed, vec![v4(192, 168, 1, 10)]);
+    assert_eq!(change.summary.probed, 1);
+    assert_eq!(
+        change.summary.moved,
+        vec![PeerSourceMove {
+            peer: peer(1),
+            before: Some(v4(192, 168, 1, 10)),
+            after: Some(v4(10, 40, 0, 7)),
+        }]
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_peer_losing_its_route_is_reported() {
+    // The route to this peer is gone, so it is stranded on whatever socket it
+    // holds — the single most important case to report, and the one a
+    // "compare the addresses we can see" fingerprint would miss because the
+    // absence of a route is not an address.
+    let up = all_from(&[peer(1)], Some(v4(192, 168, 1, 10)));
+    let down = all_from(&[peer(1)], None);
+    let (sampler, _) = scripted(vec![up, down]);
+    let (tx, mut rx) = mpsc::channel(1);
+
+    tokio::spawn(run_detector(tx, cfg(1, 0), sampler, timer_wake(1)));
+
+    let change = expect_change(&mut rx).await;
+    assert_eq!(change.summary.moved.len(), 1);
+    assert_eq!(change.summary.moved[0].after, None);
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_peer_joining_is_absorbed_rather_than_reported() {
+    // Peer churn is ordinary node behaviour and says nothing about the medium.
+    // The reaction is to drop every connected socket and heartbeat every peer,
+    // so firing it every time a peer authenticates would make a busy node
+    // continuously tear down its own send fast path.
+    let one = all_from(&[peer(1)], Some(v4(192, 168, 1, 10)));
+    let two = all_from(&[peer(1), peer(2)], Some(v4(192, 168, 1, 10)));
+    let (sampler, _) = scripted(vec![one, two]);
+    let (tx, mut rx) = mpsc::channel(1);
+
+    tokio::spawn(run_detector(tx, cfg(1, 0), sampler, timer_wake(1)));
+
+    expect_quiet(&mut rx, "a peer appearing is not a medium change").await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_peer_leaving_is_absorbed_rather_than_reported() {
+    let two = all_from(&[peer(1), peer(2)], Some(v4(192, 168, 1, 10)));
+    let one = all_from(&[peer(1)], Some(v4(192, 168, 1, 10)));
+    let (sampler, _) = scripted(vec![two, one]);
+    let (tx, mut rx) = mpsc::channel(1);
+
+    tokio::spawn(run_detector(tx, cfg(1, 0), sampler, timer_wake(1)));
+
+    expect_quiet(&mut rx, "a peer being reaped is not a medium change").await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_peer_that_joins_is_compared_on_the_sample_after() {
+    // The other half of absorbing churn: `last` has to take the new peer on
+    // board, or a peer authenticated after startup would sit outside every
+    // future comparison and its medium changes would never be seen.
+    let source = Some(v4(192, 168, 1, 10));
+    let one = all_from(&[peer(1)], source);
+    let two = all_from(&[peer(1), peer(2)], source);
+    let moved = NetFingerprint::for_test(&[(peer(1), source), (peer(2), Some(v4(10, 40, 0, 7)))]);
+    let (sampler, _) = scripted(vec![one, two, moved]);
+    let (tx, mut rx) = mpsc::channel(1);
+
+    tokio::spawn(run_detector(tx, cfg(1, 0), sampler, timer_wake(1)));
+
+    let change = expect_change(&mut rx).await;
+    assert_eq!(
+        change.summary.moved,
+        vec![PeerSourceMove {
+            peer: peer(2),
+            before: source,
+            after: Some(v4(10, 40, 0, 7)),
+        }],
+        "the peer that joined one sample ago must be under comparison now"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn churn_during_a_handover_does_not_mask_the_handover() {
+    // Both at once: a peer leaves while the medium moves under the peer that
+    // stays. The intersection rule must ignore the departure and still report
+    // the move.
+    let before = all_from(&[peer(1), peer(2)], Some(v4(192, 168, 1, 10)));
+    let after = all_from(&[peer(1)], Some(v4(10, 40, 0, 7)));
+    let (sampler, _) = scripted(vec![before, after]);
+    let (tx, mut rx) = mpsc::channel(1);
+
+    tokio::spawn(run_detector(tx, cfg(1, 0), sampler, timer_wake(1)));
+
+    let change = expect_change(&mut rx).await;
+    assert_eq!(change.summary.moved.len(), 1);
+    assert_eq!(change.summary.moved[0].peer, peer(1));
 }
 
 #[tokio::test(start_paused = true)]
 async fn a_handover_burst_coalesces_into_one_event() {
-    // A handover is not atomic: the old address goes, then briefly nothing has
-    // a route, then the new address arrives. Reporting each step would have the
-    // handler probing every peer three times against a picture still in
-    // motion. The debounce must ride the burst out and report once, against the
-    // settled state.
-    let wlan = NetFingerprint::for_test(Some(v4(192, 168, 1, 10)), &[v4(192, 168, 1, 10)]);
-    let gone = NetFingerprint::for_test(None, &[]);
-    let cell = NetFingerprint::for_test(Some(v4(10, 40, 0, 7)), &[v4(10, 40, 0, 7)]);
+    // A handover is not atomic: the route goes, then briefly there is none, then
+    // the new one arrives. Reporting each step would have the handler probing
+    // every peer three times against a picture still in motion. The debounce
+    // must ride the burst out and report once, against the settled state.
+    let wlan = all_from(&[peer(1)], Some(v4(192, 168, 1, 10)));
+    let gone = all_from(&[peer(1)], None);
+    let cell = all_from(&[peer(1)], Some(v4(10, 40, 0, 7)));
     let (sampler, _) = scripted(vec![wlan, gone, cell]);
     let (tx, mut rx) = mpsc::channel(1);
 
@@ -111,7 +217,7 @@ async fn a_handover_burst_coalesces_into_one_event() {
         "the burst must report once, not per step"
     );
     assert_eq!(
-        change.summary.v4_source,
+        change.summary.moved[0].after,
         Some(v4(10, 40, 0, 7)),
         "the reported state must be the settled one, not the mid-handover one"
     );
@@ -120,12 +226,12 @@ async fn a_handover_burst_coalesces_into_one_event() {
 
 #[tokio::test(start_paused = true)]
 async fn a_flap_that_settles_back_reports_nothing() {
-    // An address that leaves and returns within the debounce window is not a
+    // A route that leaves and returns within the debounce window is not a
     // medium change. Reporting it would have every peer probed for nothing,
     // which on a host with churning routes is exactly the reconnect storm this
     // is meant to avoid.
-    let steady = NetFingerprint::for_test(Some(v4(192, 168, 1, 10)), &[v4(192, 168, 1, 10)]);
-    let gone = NetFingerprint::for_test(None, &[]);
+    let steady = all_from(&[peer(1)], Some(v4(192, 168, 1, 10)));
+    let gone = all_from(&[peer(1)], None);
     let (sampler, _) = scripted(vec![steady.clone(), gone, steady]);
     let (tx, mut rx) = mpsc::channel(1);
 
@@ -144,9 +250,9 @@ async fn an_unread_change_coalesces_rather_than_queues() {
     // which subsumes any number of changes. A second change arriving before the
     // first is drained must therefore drop, not queue: the node must never work
     // through a backlog of stale network states.
-    let a = NetFingerprint::for_test(Some(v4(192, 168, 1, 10)), &[v4(192, 168, 1, 10)]);
-    let b = NetFingerprint::for_test(Some(v4(10, 40, 0, 7)), &[v4(10, 40, 0, 7)]);
-    let c = NetFingerprint::for_test(Some(v4(172, 16, 3, 2)), &[v4(172, 16, 3, 2)]);
+    let a = all_from(&[peer(1)], Some(v4(192, 168, 1, 10)));
+    let b = all_from(&[peer(1)], Some(v4(10, 40, 0, 7)));
+    let c = all_from(&[peer(1)], Some(v4(172, 16, 3, 2)));
     let (sampler, _) = scripted(vec![a, b, c]);
     let (tx, mut rx) = mpsc::channel(1);
 
@@ -165,8 +271,8 @@ async fn an_unread_change_coalesces_rather_than_queues() {
 
 #[tokio::test(start_paused = true)]
 async fn a_closed_receiver_ends_the_poller() {
-    let a = NetFingerprint::for_test(Some(v4(192, 168, 1, 10)), &[]);
-    let b = NetFingerprint::for_test(Some(v4(10, 40, 0, 7)), &[]);
+    let a = all_from(&[peer(1)], Some(v4(192, 168, 1, 10)));
+    let b = all_from(&[peer(1)], Some(v4(10, 40, 0, 7)));
     let (sampler, _) = scripted(vec![a, b]);
     let (tx, rx) = mpsc::channel(1);
     drop(rx);
@@ -179,46 +285,123 @@ async fn a_closed_receiver_ends_the_poller() {
         .expect("and exit cleanly, not by panic");
 }
 
+#[tokio::test(start_paused = true)]
+async fn a_node_with_no_peers_reports_nothing() {
+    // Nothing is bound to the old path, so there is nothing to repair. The
+    // fingerprint is empty and stays empty however the host's interfaces move,
+    // which is the deliberate consequence of probing peers rather than the
+    // host.
+    let (sampler, _) = scripted(vec![NetFingerprint::for_test(&[])]);
+    let (tx, mut rx) = mpsc::channel(1);
+
+    tokio::spawn(run_detector(tx, cfg(1, 0), sampler, timer_wake(1)));
+
+    expect_quiet(&mut rx, "a node holding no peers has nothing to report").await;
+}
+
+// === Live sampling ===
+
+/// An off-link destination standing in for a peer. RFC 5737 TEST-NET-1, so the
+/// route lookup is a route lookup and nothing is reachable there even by
+/// accident. Nothing is ever sent to it.
+const OFF_LINK: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)), 9);
+
 #[test]
 fn sampling_the_live_host_is_self_consistent() {
     // Two samples taken back to back on an idle host describe the same
     // attachment. This is the property the whole detector rests on: if plain
     // sampling were noisy, every poll would look like a medium change.
-    let first = NetFingerprint::sample();
-    let second = NetFingerprint::sample();
+    let targets = [(peer(1), OFF_LINK)];
+    let first = NetFingerprint::sample(&targets);
+    let second = NetFingerprint::sample(&targets);
     assert_eq!(
         first, second,
         "consecutive samples of an unchanged host must agree"
     );
-}
-
-#[test]
-fn live_interface_addresses_exclude_loopback() {
-    // Loopback is present on every host and never changes, so including it
-    // would only add noise. Unix enumerates; elsewhere the set is empty by
-    // design and the assertion holds vacuously.
-    let sample = NetFingerprint::sample();
     assert!(
-        !sample.local_addrs.iter().any(|ip| ip.is_loopback()),
-        "loopback must not contribute to the fingerprint: {:?}",
-        sample.local_addrs
+        first.moved(&second).is_empty(),
+        "and must show no peer as having moved"
     );
 }
 
 #[test]
-fn summary_of_an_empty_diff_is_legible() {
-    let same = NetFingerprint::for_test(Some(v4(192, 168, 1, 10)), &[v4(192, 168, 1, 10)]);
-    assert_eq!(same.diff(&same).to_string(), "no visible difference");
+fn every_target_is_recorded_whether_or_not_it_has_a_route() {
+    // A peer with no route must stay in the map as `None` rather than dropping
+    // out of it. Dropping it would make "the route to this peer just vanished"
+    // indistinguishable from "this peer was reaped", and the intersection rule
+    // would then discard exactly the event the detector exists to catch. The
+    // assertion holds on a CI container with no route at all.
+    let targets = [(peer(1), OFF_LINK), (peer(2), OFF_LINK)];
+    let sample = NetFingerprint::sample(&targets);
+    assert_eq!(sample.sources.len(), 2);
+    assert!(sample.sources.contains_key(&peer(1)));
+    assert!(sample.sources.contains_key(&peer(2)));
 }
 
 #[test]
-fn summary_names_the_new_source_address() {
-    let wlan = NetFingerprint::for_test(Some(v4(192, 168, 1, 10)), &[v4(192, 168, 1, 10)]);
-    let cell = NetFingerprint::for_test(Some(v4(10, 40, 0, 7)), &[v4(10, 40, 0, 7)]);
-    let rendered = wlan.diff(&cell).to_string();
-    assert!(rendered.contains("v4 source -> 10.40.0.7"), "{}", rendered);
-    assert!(rendered.contains("+1 addr"), "{}", rendered);
-    assert!(rendered.contains("-1 addr"), "{}", rendered);
+fn a_probe_never_yields_a_loopback_or_unspecified_source() {
+    // Either of those would be the kernel declining to choose, not an answer,
+    // and treating one as an address would make the fingerprint move whenever
+    // the route lookup failed differently.
+    let sample = NetFingerprint::sample(&[(peer(1), OFF_LINK)]);
+    if let Some(Some(ip)) = sample.sources.get(&peer(1)) {
+        assert!(!ip.is_loopback(), "loopback source for an off-link probe");
+        assert!(
+            !ip.is_unspecified(),
+            "unspecified source reported as an answer"
+        );
+    }
+}
+
+// === Summary rendering ===
+
+#[test]
+fn summary_of_nothing_moving_is_legible() {
+    let summary = NetChangeSummary {
+        moved: Vec::new(),
+        probed: 4,
+    };
+    assert_eq!(summary.to_string(), "no visible difference");
+}
+
+#[test]
+fn summary_names_the_peer_and_its_new_source() {
+    let wlan = all_from(&[peer(0xab)], Some(v4(192, 168, 1, 10)));
+    let cell = all_from(&[peer(0xab)], Some(v4(10, 40, 0, 7)));
+    let summary = NetChangeSummary {
+        moved: wlan.moved(&cell),
+        probed: 1,
+    };
+    let rendered = summary.to_string();
+    assert!(rendered.contains("1/1 peers"), "{}", rendered);
+    assert!(rendered.contains("abababab -> 10.40.0.7"), "{}", rendered);
+}
+
+#[test]
+fn summary_says_when_a_peer_lost_its_route() {
+    let up = all_from(&[peer(1)], Some(v4(192, 168, 1, 10)));
+    let down = all_from(&[peer(1)], None);
+    let summary = NetChangeSummary {
+        moved: up.moved(&down),
+        probed: 1,
+    };
+    assert!(summary.to_string().contains("no route"), "{}", summary);
+}
+
+#[test]
+fn summary_truncates_a_whole_table_moving_at_once() {
+    // The common case is every peer moving together, and a log line naming a
+    // hundred of them is not a log line.
+    let peers: Vec<NodeAddr> = (1..=10).map(peer).collect();
+    let before = all_from(&peers, Some(v4(192, 168, 1, 10)));
+    let after = all_from(&peers, Some(v4(10, 40, 0, 7)));
+    let summary = NetChangeSummary {
+        moved: before.moved(&after),
+        probed: peers.len(),
+    };
+    let rendered = summary.to_string();
+    assert!(rendered.contains("10/10 peers"), "{}", rendered);
+    assert!(rendered.contains("+7 more"), "{}", rendered);
 }
 
 // === Wake source ===
@@ -228,8 +411,8 @@ fn summary_names_the_new_source_address() {
 /// is an hour, so only the ping can be what woke the detector.
 #[tokio::test(start_paused = true)]
 async fn an_event_ping_wakes_the_detector_before_the_timer_would() {
-    let wlan = NetFingerprint::for_test(Some(v4(192, 168, 1, 10)), &[v4(192, 168, 1, 10)]);
-    let cell = NetFingerprint::for_test(Some(v4(10, 40, 0, 7)), &[v4(10, 40, 0, 7)]);
+    let wlan = all_from(&[peer(1)], Some(v4(192, 168, 1, 10)));
+    let cell = all_from(&[peer(1)], Some(v4(10, 40, 0, 7)));
     let (sampler, _) = scripted(vec![wlan, cell]);
     let (tx, mut rx) = mpsc::channel(1);
     let (pings, ping_rx) = mpsc::channel(1);
@@ -240,7 +423,7 @@ async fn an_event_ping_wakes_the_detector_before_the_timer_would() {
     pings.send(()).await.expect("the backend can ping");
 
     let change = expect_change(&mut rx).await;
-    assert_eq!(change.summary.v4_source, Some(v4(10, 40, 0, 7)));
+    assert_eq!(change.summary.moved[0].after, Some(v4(10, 40, 0, 7)));
 }
 
 /// A netlink socket drops messages under memory pressure, and a backend can go
@@ -248,8 +431,8 @@ async fn an_event_ping_wakes_the_detector_before_the_timer_would() {
 /// so an event-driven backend is never worse than the poller it replaced.
 #[tokio::test(start_paused = true)]
 async fn the_backstop_still_fires_when_the_backend_says_nothing() {
-    let wlan = NetFingerprint::for_test(Some(v4(192, 168, 1, 10)), &[v4(192, 168, 1, 10)]);
-    let cell = NetFingerprint::for_test(Some(v4(10, 40, 0, 7)), &[v4(10, 40, 0, 7)]);
+    let wlan = all_from(&[peer(1)], Some(v4(192, 168, 1, 10)));
+    let cell = all_from(&[peer(1)], Some(v4(10, 40, 0, 7)));
     let (sampler, _) = scripted(vec![wlan, cell]);
     let (tx, mut rx) = mpsc::channel(1);
     // Held, never sent on: the backend is alive but has missed the event.
@@ -260,7 +443,7 @@ async fn the_backstop_still_fires_when_the_backend_says_nothing() {
 
     let change = expect_change(&mut rx).await;
     assert_eq!(
-        change.summary.v4_source,
+        change.summary.moved[0].after,
         Some(v4(10, 40, 0, 7)),
         "the backstop must reach the change the backend missed"
     );
@@ -271,8 +454,8 @@ async fn the_backstop_still_fires_when_the_backend_says_nothing() {
 /// worse still.
 #[tokio::test(start_paused = true)]
 async fn a_dead_backend_falls_back_to_the_timer() {
-    let wlan = NetFingerprint::for_test(Some(v4(192, 168, 1, 10)), &[v4(192, 168, 1, 10)]);
-    let cell = NetFingerprint::for_test(Some(v4(10, 40, 0, 7)), &[v4(10, 40, 0, 7)]);
+    let wlan = all_from(&[peer(1)], Some(v4(192, 168, 1, 10)));
+    let cell = all_from(&[peer(1)], Some(v4(10, 40, 0, 7)));
     let (sampler, _) = scripted(vec![wlan, cell]);
     let (tx, mut rx) = mpsc::channel(1);
     let (pings, ping_rx) = mpsc::channel(1);
@@ -285,7 +468,7 @@ async fn a_dead_backend_falls_back_to_the_timer() {
 
     let change = expect_change(&mut rx).await;
     assert_eq!(
-        change.summary.v4_source,
+        change.summary.moved[0].after,
         Some(v4(10, 40, 0, 7)),
         "detection must survive the backend it was using"
     );
@@ -408,8 +591,8 @@ async fn a_route_change_alone_reaches_the_watcher() {
 /// several times a second across the whole peer set.
 #[tokio::test(start_paused = true)]
 async fn reports_are_spaced_out_under_clean_flapping() {
-    let a = NetFingerprint::for_test(Some(v4(192, 168, 1, 10)), &[v4(192, 168, 1, 10)]);
-    let b = NetFingerprint::for_test(Some(v4(10, 40, 0, 7)), &[v4(10, 40, 0, 7)]);
+    let a = all_from(&[peer(1)], Some(v4(192, 168, 1, 10)));
+    let b = all_from(&[peer(1)], Some(v4(10, 40, 0, 7)));
     // Alternates every sample: each poll sees a settled but different picture.
     let calls = Arc::new(AtomicUsize::new(0));
     let counter = calls.clone();
@@ -437,5 +620,158 @@ async fn reports_are_spaced_out_under_clean_flapping() {
         "consecutive reports must be at least {:?} apart, got {:?}",
         MIN_CHANGE_INTERVAL,
         started.elapsed()
+    );
+}
+
+/// The claim this whole shape exists to make: an interface appearing that is
+/// not the route to any peer does not move the fingerprint.
+///
+/// This is the case that made the host-wide address set unusable — a container
+/// bridge, a VPN, a `veth` pair or a tunnel coming up moved it, and the node
+/// answered by dropping every connected socket and heartbeating every peer, for
+/// a `docker compose up`. Here a second interface arrives with an address and a
+/// subnet of its own, carrying no route to the peer, and nothing is reported.
+///
+/// Structurally this cannot fail while the fingerprint holds only per-peer
+/// probe results — there is no host-wide enumeration left in the module to go
+/// wrong. The test is here so that a future signal added back into
+/// `NetFingerprint::sample` has to answer to it.
+///
+/// Like the watcher test above, this needs `CAP_NET_ADMIN` in a namespace it
+/// may reconfigure:
+///
+/// ```text
+/// unshare -rn cargo test --lib netmon -- --ignored --nocapture
+/// ```
+#[cfg(target_os = "linux")]
+#[tokio::test]
+#[ignore = "needs CAP_NET_ADMIN in a private netns; run under `unshare -rn`"]
+async fn an_interface_no_peer_is_reached_through_does_not_move_the_fingerprint() {
+    use futures::TryStreamExt;
+    use std::net::Ipv4Addr;
+
+    // Its own destination, in RFC 5737 TEST-NET-2 rather than the TEST-NET-1
+    // that [`OFF_LINK`] uses: `unshare -rn` gives the whole test binary one
+    // namespace, so the routes the netlink test above installs are still there
+    // and a shared prefix collides with EEXIST depending on the order they run.
+    const NET: Ipv4Addr = Ipv4Addr::new(198, 51, 100, 0);
+    const DEST: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1)), 9);
+
+    /// Bring up a dummy interface carrying `addr/24`, returning its index.
+    async fn dummy_up(handle: &rtnetlink::Handle, name: &str, addr: Ipv4Addr) -> u32 {
+        handle
+            .link()
+            .add(rtnetlink::LinkDummy::new(name).build())
+            .execute()
+            .await
+            .expect("creating a dummy link needs CAP_NET_ADMIN in this namespace");
+        let index = handle
+            .link()
+            .get()
+            .match_name(name.to_string())
+            .execute()
+            .try_next()
+            .await
+            .expect("link query")
+            .expect("the link just created exists")
+            .header
+            .index;
+        handle
+            .address()
+            .add(index, std::net::IpAddr::V4(addr), 24)
+            .execute()
+            .await
+            .expect("adding an address");
+        handle
+            .link()
+            .set(rtnetlink::LinkUnspec::new_with_index(index).up().build())
+            .execute()
+            .await
+            .expect("bringing the link up");
+        index
+    }
+
+    let (connection, handle, _) = rtnetlink::new_connection().expect("netlink connection");
+    tokio::spawn(connection);
+
+    // The medium the peer is actually reached over: an interface plus the
+    // default route out of it.
+    let carrier = dummy_up(&handle, "mc-carrier", Ipv4Addr::new(10, 99, 0, 1)).await;
+    handle
+        .route()
+        .add(
+            rtnetlink::RouteMessageBuilder::<Ipv4Addr>::new()
+                .output_interface(carrier)
+                .build(),
+        )
+        .execute()
+        .await
+        .expect("adding a default route");
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let targets = [(peer(1), DEST)];
+    let before = NetFingerprint::sample(&targets);
+    assert_eq!(
+        before.sources.get(&peer(1)),
+        Some(&Some(IpAddr::V4(Ipv4Addr::new(10, 99, 0, 1)))),
+        "the peer must be reached over the carrier before anything else appears, \
+         or this test proves nothing about what happens next"
+    );
+
+    // The interloper: a bridge-shaped interface with its own subnet, exactly
+    // what `docker compose up` leaves behind. It is up, it is not loopback, and
+    // it carries an address — every property the old host-wide set keyed on —
+    // but no peer is reached through it.
+    dummy_up(&handle, "mc-bridge", Ipv4Addr::new(172, 30, 0, 1)).await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let after = NetFingerprint::sample(&targets);
+    assert_eq!(
+        before.moved(&after),
+        Vec::new(),
+        "an interface carrying no route to any peer must not be a medium change"
+    );
+
+    // The other half, in the same namespace and against the same live sampler:
+    // put a more specific route to the peer out of the interloper, and the
+    // fingerprint must move with it. Two things ride on this. It stops the
+    // assertion above passing because sampling had quietly stopped working,
+    // which is the failure mode a negative assertion is worst at catching. And
+    // it is the per-peer route case in its own right — the default route never
+    // moves here, nothing about the host's attachment changes, and no
+    // host-wide sample could represent this at all.
+    let bridge = handle
+        .link()
+        .get()
+        .match_name("mc-bridge".to_string())
+        .execute()
+        .try_next()
+        .await
+        .expect("link query")
+        .expect("mc-bridge exists")
+        .header
+        .index;
+    handle
+        .route()
+        .add(
+            rtnetlink::RouteMessageBuilder::<Ipv4Addr>::new()
+                .destination_prefix(NET, 24)
+                .output_interface(bridge)
+                .build(),
+        )
+        .execute()
+        .await
+        .expect("adding a more specific route to the peer");
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let moved = after.moved(&NetFingerprint::sample(&targets));
+    assert_eq!(
+        moved,
+        vec![PeerSourceMove {
+            peer: peer(1),
+            before: Some(IpAddr::V4(Ipv4Addr::new(10, 99, 0, 1))),
+            after: Some(IpAddr::V4(Ipv4Addr::new(172, 30, 0, 1))),
+        }],
+        "the route to the peer moving is exactly what must be reported"
     );
 }

--- a/src/node/netmon/tests.rs
+++ b/src/node/netmon/tests.rs
@@ -1044,3 +1044,58 @@ async fn an_interface_going_down_is_reported_only_when_a_peer_was_reached_over_i
         "losing every path this test installed is a medium change"
     );
 }
+
+/// The group mask the detector actually ends up subscribed to, read back from
+/// the kernel.
+///
+/// This is the one property of the netlink backend that CI could not check.
+/// `a_route_change_alone_reaches_the_watcher` discriminates a wrong mask by
+/// provoking a real route change, but it needs `CAP_NET_ADMIN` and is skipped
+/// everywhere CI runs — so a regression to link-events-only would have passed
+/// every gate while the detector silently stopped seeing the default route
+/// move, which is the change it exists to catch.
+///
+/// A wrong mask cannot be caught by watching the bind: subscribing to the
+/// wrong groups succeeds exactly like subscribing to the right ones, and only
+/// differs in what never arrives afterwards. So this asks the kernel what the
+/// socket is subscribed to instead, which needs no privileges at all.
+///
+/// It goes through `build_wake_source` rather than constructing a watcher
+/// directly, so it is the production path being asserted on and not a second
+/// copy of the same constant.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[tokio::test]
+async fn the_detector_subscribes_to_the_route_groups_not_just_link() {
+    use crate::transport::watcher::groups;
+
+    let wake = build_wake_source(&cfg(5, 250));
+    // Asserted, not skipped. An early return here would make this test green in
+    // exactly the environment that differs from a real check — a sandbox where
+    // the bind is refused — so a mask regression would pass everywhere the
+    // subscription could not be inspected. `the_egress_path_mask_opens_a_source`
+    // already holds the same line: the bind is expected to work on Linux.
+    let subscribed = wake.subscribed_groups().expect(
+        "the detector must have a live netlink subscription to inspect; without one \
+         this test cannot say anything about the group mask",
+    );
+
+    assert_eq!(
+        subscribed,
+        groups::EGRESS_PATH,
+        "the detector must be subscribed to the egress-path groups it asked for"
+    );
+    for (name, group) in [
+        ("IPV4_ROUTE", groups::IPV4_ROUTE),
+        ("IPV6_ROUTE", groups::IPV6_ROUTE),
+        ("IPV4_IFADDR", groups::IPV4_IFADDR),
+        ("IPV6_IFADDR", groups::IPV6_IFADDR),
+    ] {
+        assert_ne!(
+            subscribed & group,
+            0,
+            "{name} is missing: a default route moving between two interfaces that both \
+             stay up emits nothing in the link group, so without this the detector would \
+             never fire for the change it exists to catch"
+        );
+    }
+}

--- a/src/node/netmon/tests.rs
+++ b/src/node/netmon/tests.rs
@@ -400,6 +400,25 @@ fn sampling_the_live_host_is_self_consistent() {
     );
 }
 
+/// The live-probe tests above are all satisfied by a `preferred_source` that
+/// returns `None` for everything: two all-`None` samples are self-consistent,
+/// the recorded-keys test never inspects a value, and the loopback assertion
+/// skips through its `if let`. This one pins that the probe actually answers.
+///
+/// Loopback is the destination because it is routable on any host that can run
+/// this suite, including a container started with `--network none`, and the
+/// source for it is loopback itself.
+#[test]
+fn a_probe_to_loopback_answers_with_loopback() {
+    let dest = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9);
+    let sample = NetFingerprint::sample(&[target(peer(1), dest)]);
+    assert_eq!(
+        sample.sources.get(&peer(1)).map(|p| p.current),
+        Some(Some(IpAddr::V4(Ipv4Addr::LOCALHOST))),
+        "the probe must return the kernel's source address, not None"
+    );
+}
+
 #[test]
 fn every_target_is_recorded_whether_or_not_it_has_a_route() {
     // A peer with no route must stay in the map as `None` rather than dropping
@@ -450,7 +469,13 @@ fn summary_names_the_peer_and_its_new_source() {
     };
     let rendered = summary.to_string();
     assert!(rendered.contains("1/1 peers"), "{}", rendered);
-    assert!(rendered.contains("abababab -> 10.40.0.7"), "{}", rendered);
+    // Both ends, and the peer id in the same shape every other operator
+    // surface prints, so a line found in `show_peers` matches here.
+    assert!(
+        rendered.contains("abababab... 192.168.1.10 -> 10.40.0.7"),
+        "{}",
+        rendered
+    );
 }
 
 #[test]
@@ -683,7 +708,11 @@ async fn reports_are_spaced_out_under_clean_flapping() {
     let (tx, mut rx) = mpsc::channel(1);
 
     // Poll far faster than the pacing floor, so only the floor can space these.
-    tokio::spawn(run_detector(tx, cfg(1, 0), sampler, timer_wake(1)));
+    // Not `timer_wake(1)`: a one-second poll against a one-second floor makes
+    // the two indistinguishable, and deleting the pacing block would still
+    // produce one-second spacing and still pass.
+    let wake = WakeSource::timer_only(Duration::from_millis(100));
+    tokio::spawn(run_detector(tx, cfg(1, 0), sampler, wake));
 
     let first = expect_change(&mut rx).await;
     let started = tokio::time::Instant::now();

--- a/src/node/tests/heartbeat.rs
+++ b/src/node/tests/heartbeat.rs
@@ -123,3 +123,163 @@ async fn heartbeat_unaffected_without_rekey() {
 
     cleanup_nodes(&mut nodes).await;
 }
+
+/// Set `node.heartbeat_interval_secs`, the knob the retry gate must not floor.
+fn set_heartbeat_interval(node: &mut crate::node::Node, secs: u64) {
+    node.replace_context(|ctx| {
+        let mut cfg = (*ctx.config).clone();
+        cfg.node.heartbeat_interval_secs = secs;
+        ctx.config = std::sync::Arc::new(cfg);
+    });
+}
+
+/// Rewind a peer's heartbeat bookkeeping by `age`, as if that long had passed
+/// since its last successful send.
+///
+/// The sweep reads `std::time::Instant`, which tokio's paused clock does not
+/// move, so elapsed time is staged on the peer rather than waited out. Sets
+/// both timestamps, which is the state a *healthy* peer is in.
+fn age_heartbeat(node: &mut crate::node::Node, addr: &NodeAddr, age: Duration) {
+    let then = std::time::Instant::now() - age;
+    node.peers
+        .get_mut(addr)
+        .expect("peer present")
+        .mark_heartbeat_sent(then);
+}
+
+/// **The retry gate must not floor a healthy peer's configured interval.**
+///
+/// A successful send stamps `last_heartbeat_sent` and `last_heartbeat_attempt`
+/// with the same instant. Gating every peer on the attempt timestamp therefore
+/// gates the healthy path too, and the effective interval becomes the larger of
+/// the configured value and `HEARTBEAT_RETRY_INTERVAL` — so a configured 1s
+/// becomes 2s, silently, with nothing validating the value and nothing saying
+/// why. `src/node/tests/tcp.rs` already configures 1s against a 3s dead
+/// timeout, which is the margin that would quietly halve.
+#[tokio::test]
+async fn a_healthy_peer_is_heartbeated_on_its_configured_interval() {
+    let mut nodes = run_tree_test(2, &[(0, 1)], false).await;
+    verify_tree_convergence(&nodes);
+
+    let addr_1 = *nodes[1].node.node_addr();
+    set_heartbeat_interval(&mut nodes[0].node, 1);
+
+    // Past the configured interval, short of the failure-retry interval. That
+    // window is the whole defect: healthy, due, and gated anyway.
+    age_heartbeat(&mut nodes[0].node, &addr_1, Duration::from_millis(1_200));
+    let before = nodes[0]
+        .node
+        .get_peer(&addr_1)
+        .expect("peer 1 is established")
+        .last_heartbeat_sent()
+        .expect("staged above");
+
+    nodes[0].node.check_link_heartbeats().await;
+
+    let after = nodes[0]
+        .node
+        .get_peer(&addr_1)
+        .expect("peer 1 is still established")
+        .last_heartbeat_sent()
+        .expect("still sent");
+    assert!(
+        after > before,
+        "a healthy peer must be heartbeated on its configured interval, not \
+         floored at the failure-retry interval"
+    );
+
+    cleanup_nodes(&mut nodes).await;
+}
+
+/// The other half: after a send that *failed*, the retry is spaced out rather
+/// than reattempted on the very next tick.
+///
+/// Without that spacing a peer whose send keeps failing is retried every tick,
+/// and the send behind it can await an unbounded stream write on the rx loop.
+/// The peer is re-pinned onto a UDP transport that was never started, so its
+/// send fails with `NotStarted` before touching a socket.
+#[tokio::test]
+async fn a_failing_peer_is_retried_after_the_gap_and_not_before() {
+    use crate::transport::{TransportAddr, TransportHandle, TransportId, packet_channel};
+
+    let mut nodes = run_tree_test(2, &[(0, 1)], false).await;
+    verify_tree_convergence(&nodes);
+
+    let addr_1 = *nodes[1].node.node_addr();
+    set_heartbeat_interval(&mut nodes[0].node, 1);
+
+    let dead_id = TransportId::new(91);
+    let (tx, _rx) = packet_channel(64);
+    nodes[0].node.transports.insert(
+        dead_id,
+        TransportHandle::Udp(crate::transport::udp::UdpTransport::new(
+            dead_id,
+            None,
+            crate::config::UdpConfig::default(),
+            tx,
+        )),
+    );
+    nodes[0]
+        .node
+        .peers
+        .get_mut(&addr_1)
+        .expect("peer 1 is established")
+        .set_current_addr(dead_id, TransportAddr::from_string("10.0.0.2:2121"));
+
+    // Long overdue and healthy-looking, so the sweep will try.
+    age_heartbeat(&mut nodes[0].node, &addr_1, Duration::from_secs(10));
+    nodes[0].node.check_link_heartbeats().await;
+
+    let attempt_1 = nodes[0]
+        .node
+        .get_peer(&addr_1)
+        .expect("peer 1 is established")
+        .last_heartbeat_attempt()
+        .expect("a failed send is still an attempt");
+    assert!(
+        nodes[0]
+            .node
+            .get_peer(&addr_1)
+            .unwrap()
+            .last_heartbeat_sent()
+            .expect("staged")
+            < attempt_1,
+        "the failed send must not have stamped a success"
+    );
+
+    // Immediately after: still inside the gap, so no second attempt.
+    nodes[0].node.check_link_heartbeats().await;
+    assert_eq!(
+        nodes[0]
+            .node
+            .get_peer(&addr_1)
+            .expect("peer 1 is established")
+            .last_heartbeat_attempt(),
+        Some(attempt_1),
+        "a failing peer must not be retried on the very next tick"
+    );
+
+    // Stage the gap as elapsed, keeping the attempt newer than the success so
+    // the peer still reads as "last one failed".
+    let past = std::time::Instant::now() - Duration::from_secs(3);
+    nodes[0]
+        .node
+        .peers
+        .get_mut(&addr_1)
+        .expect("peer present")
+        .mark_heartbeat_attempt(past);
+
+    nodes[0].node.check_link_heartbeats().await;
+    let attempt_2 = nodes[0]
+        .node
+        .get_peer(&addr_1)
+        .expect("peer 1 is established")
+        .last_heartbeat_attempt()
+        .expect("still attempted");
+    assert!(
+        attempt_2 > past,
+        "a failing peer must be retried once the gap has passed"
+    );
+
+    cleanup_nodes(&mut nodes).await;
+}

--- a/src/node/tests/netmon.rs
+++ b/src/node/tests/netmon.rs
@@ -9,7 +9,7 @@ use super::spanning_tree::*;
 use super::*;
 use crate::config::PeerConfig;
 use crate::config::TcpConfig;
-use crate::node::netmon::NetChange;
+use crate::node::netmon::{NetChange, NetFingerprint, ProbeTarget};
 use crate::transport::tcp::TcpTransport;
 use crate::transport::{TransportAddr, TransportHandle, TransportId, packet_channel};
 
@@ -37,7 +37,7 @@ fn identity_of(nodes: &[TestNode], j: usize) -> PeerIdentity {
 /// The socket is opened against a discard port on loopback: nothing is ever
 /// sent through it, and the test only cares whether the handle survives a
 /// medium change.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn install_connected_udp(node: &mut Node, addr: &NodeAddr, transport_id: TransportId) {
     let local: std::net::SocketAddr = "0.0.0.0:0".parse().unwrap();
     let peer_sa: std::net::SocketAddr = "127.0.0.1:9".parse().unwrap();
@@ -78,7 +78,7 @@ fn install_connected_udp(node: &mut Node, addr: &NodeAddr, transport_id: Transpo
 /// Observed in the field as a peering that carried exactly one packet after a
 /// route change and then stalled until the 30s liveness timeout, reporting
 /// itself connected the whole time.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[tokio::test]
 async fn a_medium_change_drops_connected_sockets_pinned_to_the_old_path() {
     let mut nodes = run_tree_test(2, &[(0, 1)], false).await;
@@ -415,7 +415,7 @@ async fn only_a_peer_with_an_ip_endpoint_reaches_the_probe() {
 /// every peer, so every peer joining would report a medium change: precisely
 /// the "peer churn fires the fan-out" behaviour the intersection rule exists to
 /// prevent. Nothing renders `bound_source`, so no other test would notice.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[tokio::test]
 async fn a_peers_connected_socket_publishes_the_source_it_was_pinned_to() {
     let mut nodes = run_tree_test(2, &[(0, 1)], false).await;
@@ -451,12 +451,55 @@ async fn a_peers_connected_socket_publishes_the_source_it_was_pinned_to() {
     // source — a real address, and demonstrably not the `0.0.0.0` the bind was
     // requested with.
     install_connected_udp(&mut nodes[0].node, &addr_1, transport_id);
+    // The harness peers sit on a synthetic `loopback:1` address, which is
+    // correctly not probeable. Re-pin to a numeric endpoint on the same
+    // transport so the row reaches the probe at all — the pinned source is a
+    // property of the socket, not of the address, and survives this.
+    nodes[0]
+        .node
+        .peers
+        .get_mut(&addr_1)
+        .expect("peer 1 is established")
+        .set_current_addr(transport_id, TransportAddr::from_string("10.0.0.2:2121"));
     nodes[0].node.record_stats_history();
 
     assert_eq!(
         row(&nodes[0].node).bound_source,
         Some(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
         "the published source must be what connect(2) pinned, not the wildcard bind"
+    );
+
+    // Publishing it is only half the wiring. Nothing else asserts that
+    // `probe_targets` carries `bound_source` through to the target, so
+    // substituting `None` there leaves the whole suite green while silently
+    // restoring the bug the first-sight rule exists to fix — the same failure
+    // class as reading the wildcard `local_addr()`, one layer further on.
+    let snapshot = nodes[0].node.entities_snapshot.load_full();
+    let target = crate::node::netmon::probe_targets(&snapshot)
+        .into_iter()
+        .find(|t| t.peer == addr_1)
+        .expect("an established UDP peer must be probeable");
+    assert_eq!(
+        target.bound,
+        Some(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
+        "the pinned source must reach the probe target, not stop at the row"
+    );
+
+    // And the last link: `sample()` has to carry it into the fingerprint, or a
+    // first-seen peer is judged against nothing again. An empty previous
+    // fingerprint is exactly the first-sight case, and the peer's socket is
+    // pinned to loopback while the probe answers for a routable destination,
+    // so the two disagree and a move must be reported.
+    let sampled = NetFingerprint::sample(&[ProbeTarget {
+        peer: addr_1,
+        dest: "192.0.2.1:9".parse().unwrap(),
+        bound: Some(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
+        bind: None,
+    }]);
+    assert!(
+        !NetFingerprint::default().moved(&sampled).is_empty(),
+        "sample() must carry the pinned source into the fingerprint, or first \
+         sight has nothing to judge against"
     );
 
     cleanup_nodes(&mut nodes).await;

--- a/src/node/tests/netmon.rs
+++ b/src/node/tests/netmon.rs
@@ -332,12 +332,69 @@ async fn only_a_peer_with_an_ip_endpoint_reaches_the_probe() {
 
         let got = crate::node::netmon::probe_targets(&snapshot)
             .into_iter()
-            .find(|(peer, _)| *peer == addr_1)
-            .map(|(_, dest)| dest);
+            .find(|t| t.peer == addr_1)
+            .map(|t| t.dest);
 
         let want = expected.map(|s| s.parse::<std::net::SocketAddr>().unwrap());
         assert_eq!(got, want, "{}: {}", addr, why);
     }
+
+    cleanup_nodes(&mut nodes).await;
+}
+
+/// The seed the join-window fix rests on, wired end to end.
+///
+/// A peer the detector has not seen before is judged against the source its
+/// connected socket was pinned to, and that value has to be the address
+/// `connect(2)` actually chose — not the wildcard the bind was requested with.
+/// `ConnectedPeerSocket::local_addr()` is the wildcard (`0.0.0.0:port`), and
+/// reading *that* would compare an unspecified address against a real one for
+/// every peer, so every peer joining would report a medium change: precisely
+/// the "peer churn fires the fan-out" behaviour the intersection rule exists to
+/// prevent. Nothing renders `bound_source`, so no other test would notice.
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn a_peers_connected_socket_publishes_the_source_it_was_pinned_to() {
+    let mut nodes = run_tree_test(2, &[(0, 1)], false).await;
+    verify_tree_convergence(&nodes);
+
+    let addr_1 = *nodes[1].node.node_addr();
+    let transport_id = nodes[0]
+        .node
+        .peers
+        .get(&addr_1)
+        .and_then(|p| p.transport_id())
+        .expect("peer 1 has a transport");
+
+    // No socket yet: nothing to seed from, and the peer must say so rather
+    // than offering the wildcard.
+    nodes[0].node.record_stats_history();
+    let row = |n: &Node| {
+        n.entities_snapshot
+            .load_full()
+            .peers
+            .iter()
+            .find(|r| r.node_addr == addr_1)
+            .expect("peer 1 has a row")
+            .clone()
+    };
+    assert_eq!(
+        row(&nodes[0].node).bound_source,
+        None,
+        "a peer with no connected socket has no pinned source to be judged against"
+    );
+
+    // The helper connects to 127.0.0.1:9, so the kernel pins the loopback
+    // source — a real address, and demonstrably not the `0.0.0.0` the bind was
+    // requested with.
+    install_connected_udp(&mut nodes[0].node, &addr_1, transport_id);
+    nodes[0].node.record_stats_history();
+
+    assert_eq!(
+        row(&nodes[0].node).bound_source,
+        Some(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
+        "the published source must be what connect(2) pinned, not the wildcard bind"
+    );
 
     cleanup_nodes(&mut nodes).await;
 }

--- a/src/node/tests/netmon.rs
+++ b/src/node/tests/netmon.rs
@@ -398,3 +398,68 @@ async fn a_peers_connected_socket_publishes_the_source_it_was_pinned_to() {
 
     cleanup_nodes(&mut nodes).await;
 }
+
+/// A heartbeat that did not go out must not be counted as one that did — in
+/// the operator log, or in the peer's own idea of when it was last heard from.
+///
+/// A medium change is exactly the condition under which sends start failing,
+/// so a count of peers *selected* would read identically whether every frame
+/// left or none did, and the peer would then be suppressed for a full
+/// `heartbeat_interval_secs` on the strength of a send that never landed.
+///
+/// The peer is re-pinned onto a UDP transport that was never started, which is
+/// connectionless — so the fan-out selects it — and fails its send with
+/// `NotStarted` before touching a socket.
+#[tokio::test]
+async fn a_heartbeat_that_failed_is_not_counted_and_does_not_suppress_the_next() {
+    let mut nodes = run_tree_test(2, &[(0, 1)], false).await;
+    verify_tree_convergence(&nodes);
+
+    let addr_1 = *nodes[1].node.node_addr();
+    let peer_1 = identity_of(&nodes, 1);
+    configure_auto_peer(&mut nodes[0].node, &peer_1);
+
+    let dead_id = TransportId::new(88);
+    let (tx, _rx) = packet_channel(64);
+    nodes[0].node.transports.insert(
+        dead_id,
+        TransportHandle::Udp(crate::transport::udp::UdpTransport::new(
+            dead_id,
+            None,
+            crate::config::UdpConfig::default(),
+            tx,
+        )),
+    );
+    nodes[0]
+        .node
+        .peers
+        .get_mut(&addr_1)
+        .expect("peer 1 is established")
+        .set_current_addr(dead_id, TransportAddr::from_string("10.0.0.2:2121"));
+
+    let before = nodes[0]
+        .node
+        .get_peer(&addr_1)
+        .unwrap()
+        .last_heartbeat_sent();
+
+    let sent = nodes[0].node.heartbeat_all_peers_after_net_change().await;
+
+    assert_eq!(
+        sent, 0,
+        "the count reports sends that succeeded, not peers picked out"
+    );
+
+    let peer = nodes[0].node.get_peer(&addr_1).unwrap();
+    assert_eq!(
+        peer.last_heartbeat_sent(),
+        before,
+        "a failed heartbeat must not move the interval that says the peer has heard from us"
+    );
+    assert!(
+        peer.last_heartbeat_attempt().is_some(),
+        "the attempt is still recorded, or a failing peer would be retried every tick"
+    );
+
+    cleanup_nodes(&mut nodes).await;
+}

--- a/src/node/tests/netmon.rs
+++ b/src/node/tests/netmon.rs
@@ -102,7 +102,7 @@ async fn a_medium_change_drops_connected_sockets_pinned_to_the_old_path() {
 
     nodes[0]
         .node
-        .handle_net_change(NetChange::for_test(1))
+        .handle_net_change(NetChange::for_test_moved(1, &[addr_1]))
         .await;
 
     assert!(
@@ -114,6 +114,69 @@ async fn a_medium_change_drops_connected_sockets_pinned_to_the_old_path() {
             .is_none(),
         "a socket pinned to the old source address must not survive the change"
     );
+}
+
+/// **A peer the change did not name keeps its socket.**
+///
+/// The reaction is scoped to `change.summary.moved`, and that is not an
+/// optimisation. Keying the sample on peers put the trigger within reach of a
+/// remote party: `probe_target` is the observed source of every authentic
+/// packet, updated with no throttle, so a peer alternating between two
+/// addresses can move the fingerprint at will. Node-wide, that peer could tear
+/// down every other peering's send path on repeat. If this test starts failing
+/// because the untouched peer lost its socket, that lever is back.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[tokio::test]
+async fn a_peer_the_change_did_not_name_keeps_its_socket() {
+    let mut nodes = run_tree_test(3, &[(0, 1), (0, 2)], false).await;
+    verify_tree_convergence(&nodes);
+
+    let moved = *nodes[1].node.node_addr();
+    let untouched = *nodes[2].node.node_addr();
+    let transport_id = nodes[0].transport_id;
+    install_connected_udp(&mut nodes[0].node, &moved, transport_id);
+    install_connected_udp(&mut nodes[0].node, &untouched, transport_id);
+
+    let heartbeat_before = nodes[0]
+        .node
+        .get_peer(&untouched)
+        .unwrap()
+        .last_heartbeat_sent();
+
+    nodes[0]
+        .node
+        .handle_net_change(NetChange::for_test_moved(1, &[moved]))
+        .await;
+
+    assert!(
+        nodes[0]
+            .node
+            .get_peer(&moved)
+            .unwrap()
+            .connected_udp()
+            .is_none(),
+        "the peer that moved must lose its pinned socket"
+    );
+    assert!(
+        nodes[0]
+            .node
+            .get_peer(&untouched)
+            .unwrap()
+            .connected_udp()
+            .is_some(),
+        "a peer whose source address did not move must keep its socket"
+    );
+    assert_eq!(
+        nodes[0]
+            .node
+            .get_peer(&untouched)
+            .unwrap()
+            .last_heartbeat_sent(),
+        heartbeat_before,
+        "and must not be heartbeated for another peer's move"
+    );
+
+    cleanup_nodes(&mut nodes).await;
 }
 
 /// The rebind must not cost the peering. Everything above the socket — the
@@ -132,7 +195,7 @@ async fn a_medium_change_keeps_every_peering_intact() {
 
     nodes[0]
         .node
-        .handle_net_change(NetChange::for_test(1))
+        .handle_net_change(NetChange::for_test_moved(1, &[addr_1]))
         .await;
 
     let peer = nodes[0]
@@ -169,7 +232,7 @@ async fn every_peer_is_heartbeated_so_the_far_side_re_pins() {
 
     nodes[0]
         .node
-        .handle_net_change(NetChange::for_test(1))
+        .handle_net_change(NetChange::for_test_moved(1, &[addr_1]))
         .await;
 
     let after = nodes[0]
@@ -234,7 +297,7 @@ async fn a_peer_on_a_connection_oriented_transport_is_left_to_the_periodic_heart
 
     nodes[0]
         .node
-        .handle_net_change(NetChange::for_test(1))
+        .handle_net_change(NetChange::for_test_moved(1, &[addr_1]))
         .await;
 
     let after = nodes[0]
@@ -443,7 +506,10 @@ async fn a_heartbeat_that_failed_is_not_counted_and_does_not_suppress_the_next()
         .unwrap()
         .last_heartbeat_sent();
 
-    let sent = nodes[0].node.heartbeat_all_peers_after_net_change().await;
+    let sent = nodes[0]
+        .node
+        .heartbeat_moved_peers_after_net_change(&[addr_1])
+        .await;
 
     assert_eq!(
         sent, 0,

--- a/src/node/tests/netmon.rs
+++ b/src/node/tests/netmon.rs
@@ -257,3 +257,87 @@ async fn a_change_with_no_peers_is_harmless() {
     node.handle_net_change(NetChange::for_test(1)).await;
     assert!(node.peers.is_empty());
 }
+
+/// The detector reads the peer table through the published entity snapshot,
+/// and this is the seam: what a peer's transport address is determines whether
+/// it arrives on the other side as something to probe. Nothing else in the
+/// tree exercises `PeerRow::probe_target`, because nothing renders it — so if
+/// the publish site stopped populating it, every other test here would still
+/// pass while the detector silently probed an empty table and never reported
+/// anything again.
+///
+/// Each case re-pins the same established peer, because the address is the
+/// only variable that matters: the projection is a property of the address,
+/// not of the transport it was learned on. (The harness's own peers sit on a
+/// synthetic `loopback:1` transport, which is itself correctly unprobeable.)
+#[tokio::test]
+async fn only_a_peer_with_an_ip_endpoint_reaches_the_probe() {
+    // (address as the peer carries it, the destination the detector should
+    // probe, why)
+    let cases: [(TransportAddr, Option<&str>, &str); 6] = [
+        (
+            TransportAddr::from_string("10.0.0.2:2121"),
+            Some("10.0.0.2:2121"),
+            "an ordinary IPv4 peer is the whole point",
+        ),
+        (
+            TransportAddr::from_string("[2001:db8::1]:2121"),
+            Some("[2001:db8::1]:2121"),
+            "IPv6 literals round-trip through the row",
+        ),
+        (
+            TransportAddr::from_bytes(&[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]),
+            None,
+            "a MAC has no IP destination to ask the routing table about",
+        ),
+        (
+            TransportAddr::from_string("example.com:2121"),
+            None,
+            "resolving a hostname would put DNS on the detector's sample path",
+        ),
+        (
+            TransportAddr::from_string("abcdefghij234567.onion:2121"),
+            None,
+            "a .onion is reached through a local proxy, not a route",
+        ),
+        (
+            TransportAddr::from_string("[fe80::1%eth0]:2121"),
+            None,
+            "a scoped link-local literal is not a parseable SocketAddr",
+        ),
+    ];
+
+    let mut nodes = run_tree_test(2, &[(0, 1)], false).await;
+    verify_tree_convergence(&nodes);
+
+    let addr_1 = *nodes[1].node.node_addr();
+    let transport_id = nodes[0]
+        .node
+        .peers
+        .get(&addr_1)
+        .and_then(|p| p.transport_id())
+        .expect("peer 1 has a transport");
+
+    for (addr, expected, why) in cases {
+        nodes[0]
+            .node
+            .peers
+            .get_mut(&addr_1)
+            .expect("peer 1 is established")
+            .set_current_addr(transport_id, addr.clone());
+
+        // The snapshot is published from the tick, which is its only writer.
+        nodes[0].node.record_stats_history();
+        let snapshot = nodes[0].node.entities_snapshot.load_full();
+
+        let got = crate::node::netmon::probe_targets(&snapshot)
+            .into_iter()
+            .find(|(peer, _)| *peer == addr_1)
+            .map(|(_, dest)| dest);
+
+        let want = expected.map(|s| s.parse::<std::net::SocketAddr>().unwrap());
+        assert_eq!(got, want, "{}: {}", addr, why);
+    }
+
+    cleanup_nodes(&mut nodes).await;
+}

--- a/src/peer/active.rs
+++ b/src/peer/active.rs
@@ -249,8 +249,16 @@ pub struct ActivePeer {
     remote_epoch: Option<[u8; 8]>,
 
     // === Heartbeat ===
-    /// When we last sent a heartbeat to this peer.
+    /// When a heartbeat to this peer last *succeeded*. A send that failed does
+    /// not move this: it did not tell the peer anything, and treating it as if
+    /// it had would leave the peer un-heartbeated for a full interval on the
+    /// strength of a send that never landed.
     last_heartbeat_sent: Option<Instant>,
+    /// When a heartbeat to this peer was last *attempted*, successfully or
+    /// not. Paired with the above so a failing peer is retried sooner than the
+    /// heartbeat interval without being retried on every tick — see
+    /// `HEARTBEAT_RETRY_INTERVAL`.
+    last_heartbeat_attempt: Option<Instant>,
 
     // === Handshake Resend ===
     /// Wire-format msg2 for resend on duplicate msg1 (responder only).
@@ -311,6 +319,7 @@ impl ActivePeer {
             authenticated_at,
             remote_epoch: None,
             last_heartbeat_sent: None,
+            last_heartbeat_attempt: None,
             handshake_msg2: None,
             session_established_at: now,
             rekey_jitter_secs: draw_rekey_jitter(),
@@ -390,6 +399,7 @@ impl ActivePeer {
             authenticated_at,
             remote_epoch,
             last_heartbeat_sent: None,
+            last_heartbeat_attempt: None,
             handshake_msg2: None,
             session_established_at: now,
             rekey_jitter_secs: draw_rekey_jitter(),
@@ -796,14 +806,32 @@ impl ActivePeer {
 
     // === Heartbeat ===
 
-    /// When we last sent a heartbeat to this peer.
+    /// When a heartbeat to this peer last succeeded.
     pub fn last_heartbeat_sent(&self) -> Option<Instant> {
         self.last_heartbeat_sent
     }
 
-    /// Record that we sent a heartbeat.
+    /// Record that a heartbeat reached the transport without error.
+    ///
+    /// Call this *after* the send, and only on success. Marking before the
+    /// send makes a failed heartbeat indistinguishable from a delivered one,
+    /// which then suppresses the next attempt for a full
+    /// `heartbeat_interval_secs` even though the peer has heard nothing.
     pub fn mark_heartbeat_sent(&mut self, now: Instant) {
         self.last_heartbeat_sent = Some(now);
+        self.last_heartbeat_attempt = Some(now);
+    }
+
+    /// When a heartbeat to this peer was last attempted, whatever came of it.
+    pub fn last_heartbeat_attempt(&self) -> Option<Instant> {
+        self.last_heartbeat_attempt
+    }
+
+    /// Record that a heartbeat send was attempted. Call this before the send,
+    /// so an attempt that fails — or one that never returns — still spaces the
+    /// next one out.
+    pub fn mark_heartbeat_attempt(&mut self, now: Instant) {
+        self.last_heartbeat_attempt = Some(now);
     }
 
     // === State Updates ===

--- a/src/proto/mmp/core.rs
+++ b/src/proto/mmp/core.rs
@@ -39,8 +39,11 @@ pub(crate) struct PeerLivenessSnapshot {
     /// An FMP rekey handshake is genuinely in flight with retransmission budget
     /// left; suppresses teardown of an otherwise-silent rekey link.
     pub rekey_active: bool,
-    /// A heartbeat is due (`last_heartbeat_sent` is none, or elapsed since it is
-    /// >= the heartbeat interval).
+    /// A heartbeat is due. Two conditions, both resolved shell-side: elapsed
+    /// since the last heartbeat that *landed* is >= the heartbeat interval (or
+    /// none has), and — only when the last attempt failed — the failure-retry
+    /// gap has passed since that attempt. The retry gap deliberately does not
+    /// apply to a healthy peer, or it would floor the configured interval.
     pub heartbeat_due: bool,
 }
 
@@ -169,8 +172,15 @@ pub(crate) enum MmpAction {
     /// Reap a dead peer: the shell runs `remove_active_peer` +
     /// `schedule_reconnect` (with its wall-clock `now_ms`).
     ReapPeer { peer: NodeAddr },
-    /// Send a heartbeat to `peer`: the shell runs `mark_heartbeat_sent` and the
-    /// encrypted link send.
+    /// Send a heartbeat to `peer`: the shell runs `mark_heartbeat_attempt`,
+    /// then the encrypted link send, and `mark_heartbeat_sent` **only if that
+    /// send returned cleanly**.
+    ///
+    /// The order and the condition are the contract, not an implementation
+    /// detail. Stamping the success before the send makes a failed heartbeat
+    /// indistinguishable from a delivered one, which suppresses the next
+    /// attempt for a full interval even though the peer heard nothing; the
+    /// separate attempt stamp is what spaces the retries without doing that.
     Heartbeat { peer: NodeAddr },
     /// Build (shell: `proto/mmp/` `build_report` + `encode`) and send the given
     /// link report over the encrypted link. The interval-advancing

--- a/src/transport/udp/io/connected/socket.rs
+++ b/src/transport/udp/io/connected/socket.rs
@@ -4,7 +4,7 @@
 //! and closes it on drop. See that function's docs for why established
 //! peers get their own connected socket.
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::os::unix::io::{AsRawFd, OwnedFd, RawFd};
 
 /// A `connect()`-ed UDP socket for one established peer.
@@ -28,6 +28,9 @@ pub(crate) struct ConnectedPeerSocket {
     fd: OwnedFd,
     peer_addr: SocketAddr,
     local_addr: SocketAddr,
+    /// The source address `connect(2)` actually pinned, read back once at
+    /// construction. See [`ConnectedPeerSocket::pinned_source`].
+    pinned_source: Option<IpAddr>,
 }
 
 impl ConnectedPeerSocket {
@@ -35,10 +38,12 @@ impl ConnectedPeerSocket {
     /// `crate::transport::udp::open_connected_fd`) into an owning
     /// handle. Takes ownership of the fd; the `OwnedFd` closes it on drop.
     pub(crate) fn from_fd(fd: OwnedFd, peer_addr: SocketAddr, local_addr: SocketAddr) -> Self {
+        let pinned_source = pinned_source_of(fd.as_raw_fd());
         Self {
             fd,
             peer_addr,
             local_addr,
+            pinned_source,
         }
     }
 
@@ -50,6 +55,52 @@ impl ConnectedPeerSocket {
     pub fn local_addr(&self) -> SocketAddr {
         self.local_addr
     }
+
+    /// The source address the kernel bound when this socket was
+    /// `connect(2)`-ed, as opposed to [`Self::local_addr`], which is the
+    /// wildcard the bind was *requested* with and carries no interface
+    /// information at all.
+    ///
+    /// This is the quantity the whole connected-socket fast path turns on: the
+    /// kernel resolves the route once at connect time and pins the source
+    /// address to whichever interface was carrying it then, and never
+    /// re-evaluates. Read back once here rather than per call, because it
+    /// cannot change for the life of the socket — that being exactly the
+    /// problem. `crate::node::netmon` compares it against the address the
+    /// routing table would choose now, which is how a peer whose socket is
+    /// already stale is recognised without any earlier sample to compare
+    /// against.
+    ///
+    /// `None` if `getsockname` fails or reports a family this does not decode,
+    /// which is treated as "no answer" rather than guessed at.
+    pub(crate) fn pinned_source(&self) -> Option<IpAddr> {
+        self.pinned_source
+    }
+}
+
+/// `getsockname` on a connected UDP socket, reduced to the local IP.
+///
+/// Returns `None` on any failure: the caller's contract is that an unknown
+/// pinned source is indistinguishable from not having one, and both mean "do
+/// not draw a conclusion from this socket".
+fn pinned_source_of(fd: RawFd) -> Option<IpAddr> {
+    let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
+    let mut len = std::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+    // SAFETY: `fd` is the socket this handle owns, and `storage` / `len` are a
+    // correctly sized and initialised out-parameter pair for `getsockname`,
+    // which writes at most `len` bytes and updates `len` to what it wrote.
+    let rc =
+        unsafe { libc::getsockname(fd, &mut storage as *mut _ as *mut libc::sockaddr, &mut len) };
+    if rc < 0 {
+        return None;
+    }
+    let addr = super::super::unix::sockaddr_to_socket_addr(&storage).ok()?;
+    // An unspecified source means the kernel declined to choose — no route of
+    // that family — which is not an address and must not be compared as one.
+    if addr.ip().is_unspecified() {
+        return None;
+    }
+    Some(addr.ip())
 }
 
 impl AsRawFd for ConnectedPeerSocket {

--- a/src/transport/watcher.rs
+++ b/src/transport/watcher.rs
@@ -57,6 +57,30 @@ impl Drop for LinkEventSocket {
 }
 
 impl LinkEventSocket {
+    /// The multicast group mask this socket is actually subscribed to, read
+    /// back from the kernel rather than remembered from the bind.
+    ///
+    /// `getsockname` on a netlink socket fills `sockaddr_nl.nl_groups` with the
+    /// legacy 32-bit subscription mask, which covers every group in
+    /// [`groups`]. Reading it back is the only way to tell a watcher that
+    /// *asked* for the right groups from one that got them: a bind with a
+    /// wrong mask succeeds just as happily as a bind with the right one, and
+    /// then silently never delivers the messages the caller subscribed for.
+    #[cfg(all(test, any(target_os = "linux", target_os = "android")))]
+    fn bound_groups(&self) -> Option<u32> {
+        let mut sa: libc::sockaddr_nl = unsafe { std::mem::zeroed() };
+        let mut len = std::mem::size_of::<libc::sockaddr_nl>() as libc::socklen_t;
+        // SAFETY: `self.fd` is the netlink socket this struct owns, and `sa` /
+        // `len` are a correctly sized out-parameter pair for `getsockname`.
+        let rc = unsafe {
+            libc::getsockname(self.fd, &mut sa as *mut _ as *mut libc::sockaddr, &mut len)
+        };
+        if rc < 0 {
+            return None;
+        }
+        Some(sa.nl_groups)
+    }
+
     fn recv(&self, buf: &mut [u8]) -> std::io::Result<usize> {
         let n = unsafe { libc::recv(self.fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len(), 0) };
         if n < 0 {
@@ -216,6 +240,22 @@ impl LinkWatcher {
             errors: AtomicU32::new(0),
             given_up: AtomicBool::new(false),
         }
+    }
+
+    /// The netlink multicast groups this watcher is actually subscribed to, as
+    /// the kernel reports them.
+    ///
+    /// `None` when there is no live source, and on every platform whose backend
+    /// is `PF_ROUTE`, which has no group selection to report.
+    ///
+    /// This exists to be asserted on. A bind with the wrong group mask succeeds
+    /// exactly like a bind with the right one and then silently never delivers
+    /// what the caller subscribed for, so nothing short of reading the
+    /// subscription back can tell the two apart without provoking a real
+    /// kernel event — which needs privileges CI does not have.
+    #[cfg(all(test, any(target_os = "linux", target_os = "android")))]
+    pub(crate) fn subscribed_groups(&self) -> Option<u32> {
+        self.inner.as_ref()?.get_ref().bound_groups()
     }
 
     /// Whether an event source is actually backing this watcher.


### PR DESCRIPTION
The per-peer probe, as owed. Plus four of the six follow-ups.

Three commits: the probe, a fix to a hole the probe's own shape opens, and the
follow-ups.

## The probe

`NetFingerprint` becomes `NodeAddr -> local source address`. For every peer
whose transport address is a numeric IP endpoint, `connect(2)` a UDP socket at
it and read back the address the kernel picked. `interface_addrs()`, its
`getifaddrs` walk and the `sockaddr` decoding are gone, and with them the class
of noise you described: a container bridge, a VPN, a `veth` pair or a tunnel is
not the route to any peer, so it cannot enter the sample. On-link peers become
visible for the first time, and a more specific route moving under one peer is
representable at all.

Verified against a real kernel rather than argued: in a namespace, an interface
coming up with its own subnet moves nothing, and a more specific route to the
peer out of that same interface moves exactly that peer. `interface_addrs()`
has no call site left, so **this absorbs #145** — I spent nothing on it.

## Where I deviated from your instructions, and why

You asked for the intersection of consecutive samples, so peer churn cannot
fire the fan-out on its own. I built that, and on its own it is wrong — not in
a corner, but in a window that opens after every peer that authenticates.

`last` gains a peer only at the first wake *after* it appears. A medium change
inside that window is the detector's first sight of that peer: the intersection
is empty, nothing is reported, and the sample is adopted as the new baseline.
The event is not delayed, it is consumed. The peer's connected socket stays
pinned to the path the host just left and nothing repairs it, so the peering
black-holes to the liveness timeout — the outage this subsystem exists to
prevent. A medium change is itself what wakes the detector, so the two coincide
readily. The host-wide fingerprint did not have this hole: it sampled from
detector startup independently of any peer. Keying on peers introduces it.

Demonstrated as an A/B in the medium-change lab, with `poll_interval_secs`
raised so the move's own netlink event is the detector's first wake:

| tree | events |
|---|---|
| the probe commit alone | **0** — move swallowed entirely |
| with the fix | **1** — `1/1 peers: 85904a3e -> 172.31.61.10 sockets_rebound=1 heartbeated=1` |

My first attempt at that A/B did *not* reproduce — both sides fired, because
container churn let the detector sample the peer first. Worth saying plainly: a
single green suite run proves nothing here, which is how the original 8/8
passed over a live bug.

So a peer seen for the first time is judged against its own send path instead
of against history — the source `connect(2)` pinned its socket to, against what
the routing table would choose for it now. No baseline needed, and it asks the
question the subsystem is actually about rather than inferring it from a
difference. Your condition's purpose holds: a peer joining onto a path that has
not moved is pinned exactly where its traffic goes and reports nothing.

**This nearly went in badly.** `ConnectedPeerSocket::local_addr()` looks like
the right value and is the *wildcard* bind (`0.0.0.0:2121`) — production passes
`udp.local_addr()` into `from_fd`, which is why that accessor was dead code.
Seeding from it would have compared an unspecified address against a real one
for every peer and fired the fan-out on every join: worse than the bug being
fixed, and exactly what your intersection rule exists to prevent. The socket now
reads its pinned source back with `getsockname` once at construction.

Residual, documented at the call site: a first-seen peer with no `bound`. That
is every platform but Linux and macOS, every peer on a stream or proxied
transport on those two, and the one-tick gap before an installed socket becomes
visible. The first two are harmless — with no connected socket there is nothing
pinned to repair, and the cost is the immediate heartbeat only. The third is a
real hole: the tick publishes the snapshot before it installs sockets, so a
socket installed on tick N is first seen on tick N+1, and a peer whose path
moves inside that window does hold a pinned socket. Bounded rather than
permanent, since the ordinary diff recovers it on the next sample.

A non-wildcard `transports.udp.bind_addr` is no longer part of the residual —
see below.

## Your other condition

The peer table is reached through `entities_snapshot`; the detector holds no
node state and takes no lock. Judgment call to flag: `PeerRow` gains two typed
fields (`probe_target`, `bound_source`) rather than having the detector
re-parse the display string next to it. Re-parsing would work — MACs, `.onion`,
Nym and hostnames all fail a `SocketAddr` parse, so it is a correct filter for
free — but it would make a safety mechanism depend on a display string's
formatting and degrade silently to "detect nothing" if that changed. Same
silent-degradation shape as your netlink-mask item, so I paid two fields for
it. Say if you would rather have the re-parse.

## Follow-ups

**2, 3, 4, 5 and 6 close here — five of six, not four. 1 is not here.**

Correcting my own count: item 5 was the two documentation claims that do not
match the code. Both were still wrong at the base and both are fixed by
`879007e` in this pull request, whose message says so without connecting it to
the item.

- **2** — a failed heartbeat no longer resets the timer. The attempt is
  recorded separately and gates retries, deliberately: without that gate a
  failing peer would retry every tick, and the send behind it is item 1's
  unbounded write. Fixing 2 naively makes 1 ten times worse. The constant's doc
  says it can come down once 1 lands.
- **3** — `node.netmon.*` validated. A zero `poll_interval_secs` was silently
  clamped to 1s, so a typo produced a node polling 20x more often than
  configured, silently; now refused, and only while detection is enabled. Plus
  a cross-field check that the worst-case debounce cannot outlast
  `link_dead_timeout_secs`, since then the reaper wins and the detector cannot
  help. `MAX_DEBOUNCE_ROUNDS` is shared with the detector so the two cannot
  drift, and a test asserts the shipped defaults still validate.
- **4** — the group mask is now checked in CI. A wrong mask cannot be caught at
  the bind: subscribing to the wrong groups succeeds exactly like the right ones
  and differs only in what never arrives. So the watcher reads its subscription
  back with `getsockname` (`sockaddr_nl.nl_groups`, no privileges), and the test
  drives `build_wake_source` so it asserts on the production path rather than a
  second copy of the constant. It is a new test and runs in CI; nothing that was
  previously ignored became unignored, and `a_route_change_alone_reaches_the_watcher`
  is still ignored at head. Confirmed against the regression you
  named — reverted to link-events-only it fails `left: 1, right: 1361`.
- **6** — `heartbeated` counts sends that succeeded. A medium change is exactly
  when sends start failing, so the old count read the same whether every frame
  left or none did.

**1 is assessed and deliberately not here.** All three stream transports already
have `close_connection_async`, so bounding `write_all` and evicting on expiry is
~15 lines each, and dropping a partial write is safe if the connection goes with
it — the half-frame objection only holds while the stream stays open. But it
buys less than it looks: a bounded write still stalls the rx loop for the whole
budget, and to sit under `link_dead_timeout_secs` that budget has to be short
enough to threaten a healthy Tor circuit. The real fix is to stop needing
`&mut self` on that path so the send can leave the loop. That is a transport
change with its own tuning judgment across three hot paths, and it does not
belong in a detector rewrite. Happy to take it next.

## Verification

- Churn rules mutation-checked: union iteration fails four tests; dropping the
  first-sight seed fails only the reproduction and leaves the churn tests green,
  so the two rules are independently pinned.
- The `getsockname` wiring has its own test, failing `Some(0.0.0.0)` against
  `Some(127.0.0.1)` if the publish site reverts. Nothing renders that field, so
  nothing else would catch it.
- All 16 static gates pass — `fmt`, both clippy passes, unit tests (2352 + 39 +
  50 + 3 passed, 0 failed), build, CI parity.
- Integration suites run individually rather than as one pass, because the full
  runner exhausts memory on this host: **medium-change**, **static-mesh**,
  **chaos-churn-mixed-10** and **chaos-tcp-mesh**, all green. Those are the ones
  this touches — the medium-change lab for the detector, and the other three for
  the heartbeat-timer change, which affects all peering rather than just netmon.
  In the lab both route-move phases keep the peering intact and the negative
  control still black-holes for 12.2s with detection off. The remaining suites
  are downstream of the same gates and exercise areas this does not touch; the
  one change with global reach is the config validation, and only the
  medium-change suite sets `node.netmon.*` at all — everything else takes the
  defaults, which have a test asserting they validate. GitHub runs the full
  matrix here.
- Three `CAP_NET_ADMIN` tests pass under `unshare -rn`, including a new one for
  an interface going down and returning — the shape the docker lab deliberately
  does not cover, since it keeps both interfaces up throughout.

---

Closes #145. The probe deletes `interface_addrs()` outright, which is that
issue's whole subject, so it closes by deletion rather than by fix — the
observability question it asked becomes unfalsifiable rather than answered. I
have said so on the issue itself rather than leaving the link to imply it was
investigated.
