### PR TITLE
docs(packaging/freebsd): use version placeholders in the examples

### DIFF
--- a/packaging/freebsd/README.md
+++ b/packaging/freebsd/README.md
@@ -18,13 +18,14 @@ not compiled pending FreeBSD-specific `SO_REUSEPORT` validation.
 ./packaging/freebsd/build-pkg.sh --no-build # package existing release binaries
 ```
 
-Output: `deploy/fips-<version>-freebsd-<arch>.pkg` (e.g.
-`fips-0.5.1.dev-freebsd-amd64.pkg` — pkg versions cannot contain `-`).
+Output: `deploy/fips-<version>-freebsd-<arch>.pkg`. pkg versions cannot
+contain `-` or `+`, so both are mapped to `.`: a Cargo version of
+`<x.y.z>-dev` becomes `fips-<x.y.z>.dev-freebsd-amd64.pkg`.
 
 ## Install
 
 ```sh
-pkg add ./deploy/fips-0.5.1-freebsd-amd64.pkg
+pkg add ./deploy/fips-<version>-freebsd-<arch>.pkg
 # post-install seeds this from the sample if absent, at mode 0600
 vi /usr/local/etc/fips/fips.yaml
 sysrc fips_enable=YES fips_dns_enable=YES


### PR DESCRIPTION
The build and install examples in `packaging/freebsd/README.md` named
`v0.5.1` — the release current when they were written. Every release
since has left them describing a version nobody builds, and nothing
gates them, so the drift is silent: the only way to notice is to copy a
`pkg add` line that names a file you do not have.

The install command and the output path become `<version>`/`<arch>`. The
example illustrating the `-` and `+` to `.` mapping keeps a concrete
shape, since a placeholder alone would not show the transformation, but
uses `<x.y.z>` rather than a real release so it cannot go stale either.

Documentation only — one file, no code, no behaviour change.

Split out of the pfSense packaging branch, where it would have been
adjacent cleanup in a change that has nothing to do with the FreeBSD
README. The two are independent: no shared files, no ordering
constraint.
