### PR TITLE
fix(transport): make the invalid-hostname test independent of the search domain

### DIFF
--- a/src/transport/udp/mod.rs
+++ b/src/transport/udp/mod.rs
@@ -1029,7 +1029,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_socket_addr_invalid() {
-        let invalid = TransportAddr::from_string("nonexistent.invalid:2121");
+        let invalid = TransportAddr::from_string("nonexistent.invalid.:2121");
         assert!(resolve_socket_addr(&invalid).await.is_err());
 
         let binary = TransportAddr::new(vec![0xff, 0x80]);


### PR DESCRIPTION
`transport::udp::tests::test_resolve_socket_addr_invalid` asserts that
`nonexistent.invalid` fails to resolve. On any host whose
`/etc/resolv.conf` search domain carries a wildcard A record it does not
fail: libc appends the search domain, the wildcard answers for
`nonexistent.invalid.<domain>`, and the assertion inverts. So the test
fails on those hosts and passes everywhere else, which looks like a
flake and is not one.

The literal becomes `nonexistent.invalid.` — absolute, trailing dot —
so search-list expansion never applies and the reserved `.invalid` TLD
returns NXDOMAIN from the root regardless of the host's resolver
configuration.

One line, one test, no behaviour change. Verified on a host that
reproduced the failure: fails before the change, passes after.
