### PR TITLE
fix(testing): guard the empty env_args splat in the mesh-lab loop

### DIFF
--- a/testing/mesh-lab/run-loop.sh
+++ b/testing/mesh-lab/run-loop.sh
@@ -203,10 +203,17 @@ run_rekey_family() {
 
     (
         cd "$REPO_ROOT" || exit 1
-        env "${env_args[@]}" bash testing/static/scripts/generate-configs.sh "$variant" \
-            >>"$REP_DIR/setup.log" 2>&1
-        env "${env_args[@]}" bash testing/static/scripts/rekey-test.sh inject-config \
-            >>"$REP_DIR/setup.log" 2>&1
+        if [ "${#env_args[@]}" -gt 0 ]; then
+            env "${env_args[@]}" bash testing/static/scripts/generate-configs.sh "$variant" \
+                >>"$REP_DIR/setup.log" 2>&1
+            env "${env_args[@]}" bash testing/static/scripts/rekey-test.sh inject-config \
+                >>"$REP_DIR/setup.log" 2>&1
+        else
+            bash testing/static/scripts/generate-configs.sh "$variant" \
+                >>"$REP_DIR/setup.log" 2>&1
+            bash testing/static/scripts/rekey-test.sh inject-config \
+                >>"$REP_DIR/setup.log" 2>&1
+        fi
         docker compose "${compose_args[@]}" up -d \
             >>"$REP_DIR/setup.log" 2>&1
     )
@@ -240,7 +247,11 @@ run_rekey_family() {
     local rc=0
     (
         cd "$REPO_ROOT" || exit 1
-        env "${env_args[@]}" bash testing/static/scripts/rekey-test.sh
+        if [ "${#env_args[@]}" -gt 0 ]; then
+            env "${env_args[@]}" bash testing/static/scripts/rekey-test.sh
+        else
+            bash testing/static/scripts/rekey-test.sh
+        fi
     ) >"$REP_DIR/test-output.log" 2>&1 || rc=$?
 
     # Capture container logs before teardown


### PR DESCRIPTION
## Symptom

On macOS, `testing/mesh-lab/run-loop.sh rekey` never actually runs the suite:

```
run-loop.sh: line 206: env_args[@]: unbound variable
```

The setup subshell dies at that line, so `generate-configs.sh`, the rekey `inject-config` step, and `docker compose up -d` never run. The script does not abort (`set -uo pipefail`, no `-e`), so it carries on and runs the suite against a stack that was never started. The visible result is a **bogus rekey failure that looks like a mesh bug**, several stages downstream of the real cause — and `setup.log` is empty, because the expansion fails before the redirection is applied, so the one line naming the cause goes to the console instead.

The `rekey-accept-off` and `rekey-outbound-only` variants are unaffected.

## Root cause

`run_rekey_family()` declares the array empty and only fills it for two of its three variants:

```bash
local env_args=()                      # line 166
case "$variant" in
    rekey-accept-off)    env_args=(...) ;;
    rekey-outbound-only) env_args=(...) ;;
esac                                   # plain "rekey" matches nothing
```

So the `rekey` variant reaches the `env "${env_args[@]}"` call sites with an empty array. Under `set -u` (line 49), bash 3.2 treats an empty array expansion as unbound:

```console
$ /bin/bash -c 'set -u; a=(); env "${a[@]}" echo hi'
bash: a[@]: unbound variable
```

Bash 4.4 changed this so an empty `[@]`/`[*]` expands to zero words instead of erroring. Linux distros and CI runners ship bash 4.4+, so they never see it; macOS is frozen on bash 3.2.57, so it always does.

An empty `env_args` is the *correct* state for the baseline `rekey` variant — it means "no env overrides" — so the fix belongs at the call site, not in the `case`.

## Fix

Check the element count before splatting. `${#env_args[@]}` is safe on an empty array under `set -u` (it yields `0`), while `${env_args[@]}` is not:

```bash
if [ "${#env_args[@]}" -gt 0 ]; then
    env "${env_args[@]}" bash testing/static/scripts/generate-configs.sh "$variant" ...
else
    bash testing/static/scripts/generate-configs.sh "$variant" ...
fi
```

Dropping the `env` prefix when there is nothing to set is exactly equivalent — `env cmd` with no assignments just runs `cmd` — so behaviour is unchanged on every platform. On bash 4.4+ both branches were already equivalent; on bash 3.2 the `else` branch now does what the original intended.

The `nat-lan` call site (line 450) is deliberately left unguarded: its `env_args` is declared with an element at line 436 and can never be empty.

## Testing

- `bash -n testing/mesh-lab/run-loop.sh` passes.
- Reproduced the failure and verified the fix against a faithful standalone copy of the code path on bash 3.2.57 — before: subshell dies, all three setup steps skipped; after: all three run, exit status 0, for both the empty and populated variants.
- Test-harness only; no changes under `src/`.

Targeting `maint` per CONTRIBUTING's branch table (bug fix in material that shipped in the latest release). The same unguarded pattern is present on `master` and `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)