### PR TITLE
fix(testing): guard the empty env_args splat in the mesh-lab loop

### DIFF
--- a/testing/mesh-lab/run-loop.sh
+++ b/testing/mesh-lab/run-loop.sh
@@ -203,10 +203,17 @@ run_rekey_family() {
 
     (
         cd "$REPO_ROOT" || exit 1
-        env "${env_args[@]}" bash testing/static/scripts/generate-configs.sh "$variant" \
-            >>"$REP_DIR/setup.log" 2>&1
-        env "${env_args[@]}" bash testing/static/scripts/rekey-test.sh inject-config \
-            >>"$REP_DIR/setup.log" 2>&1
+        if [ "${#env_args[@]}" -gt 0 ]; then
+            env "${env_args[@]}" bash testing/static/scripts/generate-configs.sh "$variant" \
+                >>"$REP_DIR/setup.log" 2>&1
+            env "${env_args[@]}" bash testing/static/scripts/rekey-test.sh inject-config \
+                >>"$REP_DIR/setup.log" 2>&1
+        else
+            bash testing/static/scripts/generate-configs.sh "$variant" \
+                >>"$REP_DIR/setup.log" 2>&1
+            bash testing/static/scripts/rekey-test.sh inject-config \
+                >>"$REP_DIR/setup.log" 2>&1
+        fi
         docker compose "${compose_args[@]}" up -d \
             >>"$REP_DIR/setup.log" 2>&1
     )
@@ -240,7 +247,11 @@ run_rekey_family() {
     local rc=0
     (
         cd "$REPO_ROOT" || exit 1
-        env "${env_args[@]}" bash testing/static/scripts/rekey-test.sh
+        if [ "${#env_args[@]}" -gt 0 ]; then
+            env "${env_args[@]}" bash testing/static/scripts/rekey-test.sh
+        else
+            bash testing/static/scripts/rekey-test.sh
+        fi
     ) >"$REP_DIR/test-output.log" 2>&1 || rc=$?
 
     # Capture container logs before teardown


### PR DESCRIPTION
(i actually dont know too much about these but it seems fix some broken test on my macbook  and didnt break other stuff... others are all written by claude)

Running `run-loop.sh rekey` on macOS aborts the setup subshell with "env_args[@]: unbound variable", so generate-configs.sh, the rekey inject-config step and `docker compose up -d` never run. The script carries on and runs the suite against a stack that was never started, so the failure surfaces as a bogus rekey failure rather than a setup error -- and setup.log is empty, because the expansion fails before the redirection is applied.

run_rekey_family() declares `local env_args=()` and fills it only for the rekey-accept-off and rekey-outbound-only variants, so the plain `rekey` variant reaches the `env "${env_args[@]}"` call sites with an empty array. Under `set -u` (line 49) bash 3.2 treats an empty array expansion as unbound. Bash 4.4 stopped doing so, which is why Linux and CI never see this and only macOS's frozen bash 3.2 is affected.

Check the element count before splatting, and drop the `env` prefix when there is nothing to set -- `env cmd` with no assignments is equivalent to `cmd`, so both branches behave identically everywhere. The nat-lan call site is left unguarded on purpose: its env_args is declared with an element and can never be empty.